### PR TITLE
Add workaround for OpenVINO cache path, when it contains special characters

### DIFF
--- a/mod-openvino/CMakeLists.txt
+++ b/mod-openvino/CMakeLists.txt
@@ -27,7 +27,6 @@ include_directories(${CPP_STABLE_DIFFUSION_OV_ROOTDIR}/include )
 message("stable_diffusion_ov library = ${stable_diffusion_ov}")
 message("stable_diffusion_audio_ov library = ${stable_diffusion_audio_ov}")
 
-
 set( SOURCES
       OVNoiseSuppression.cpp
       OVNoiseSuppression.h
@@ -42,6 +41,7 @@ set( SOURCES
       htdemucs.cpp
       htdemucs.h
       OpenVINO.cpp
+      OVStringUtils.h
 )
 
 set( LIBRARIES

--- a/mod-openvino/OVMusicGeneration.cpp
+++ b/mod-openvino/OVMusicGeneration.cpp
@@ -38,6 +38,7 @@
 #include <future>
 
 #include "InterpolateAudio.h"
+#include "OVStringUtils.h"
 
 const ComponentInterfaceSymbol EffectOVMusicGeneration::Symbol{ XO("OpenVINO Music Generation") };
 
@@ -340,7 +341,10 @@ bool EffectOVMusicGeneration::Process(EffectInstance&, EffectSettings& settings)
       bool bAdvanced = (m_modeSelectionChoice == 1);
 
       FilePath cache_folder = FileNames::MkDir(wxFileName(FileNames::DataDir(), wxT("openvino-model-cache")).GetFullPath());
-      std::string cache_path = audacity::ToUTF8(wxFileName(cache_folder).GetFullPath());
+
+      //Note: Using a variant of wstring conversion that seems to work more reliably when there are special characters present in the path.
+      std::string cache_path = wstring_to_string(wxFileName(cache_folder).GetFullPath().ToStdWstring());
+
       std::cout << "cache path = " << cache_path << std::endl;
 
       wxString added_trackName;

--- a/mod-openvino/OVMusicSeparation.cpp
+++ b/mod-openvino/OVMusicSeparation.cpp
@@ -23,6 +23,8 @@
 #include "CodeConversions.h"
 #include <future>
 
+#include "OVStringUtils.h"
+
 const ComponentInterfaceSymbol EffectOVMusicSeparation::Symbol{ XO("OpenVINO Music Separation") };
 
 namespace { BuiltinEffectsModule::Registration< EffectOVMusicSeparation > reg; }
@@ -167,7 +169,9 @@ bool EffectOVMusicSeparation::Process(EffectInstance&, EffectSettings&)
          .GetFullPath());
 
       FilePath cache_folder = FileNames::MkDir(wxFileName(FileNames::DataDir(), wxT("openvino-model-cache")).GetFullPath());
-      std::string cache_path = audacity::ToUTF8(wxFileName(cache_folder).GetFullPath());
+
+      //Note: Using a variant of wstring conversion that seems to work more reliably when there are special characters present in the path.
+      std::string cache_path = wstring_to_string(wxFileName(cache_folder).GetFullPath().ToStdWstring());
 
       std::cout << "demucs_v4_path = " << demucs_v4_path << std::endl;
       std::cout << "cache_path = " << cache_path << std::endl;

--- a/mod-openvino/OVMusicStyleRemix.cpp
+++ b/mod-openvino/OVMusicStyleRemix.cpp
@@ -42,6 +42,8 @@
 #include "cpp_stable_diffusion_audio_ov/riffusion_audio_to_audio_pipeline.h"
 #include "cpp_stable_diffusion_ov/model_collateral_cache.h"
 
+#include "OVStringUtils.h"
+
 const ComponentInterfaceSymbol EffectOVMusicStyleRemix::Symbol{ XO("OpenVINO Music Style Remix") };
 
 namespace { BuiltinEffectsModule::Registration< EffectOVMusicStyleRemix > reg; }
@@ -235,7 +237,10 @@ bool EffectOVMusicStyleRemix::Process(EffectInstance&, EffectSettings& settings)
       std::cout << "riffusion_model_folder = " << riffusion_model_folder << std::endl;
 
       FilePath cache_folder = FileNames::MkDir(wxFileName(FileNames::DataDir(), wxT("openvino-model-cache")).GetFullPath());
-      std::string cache_path = audacity::ToUTF8(wxFileName(cache_folder).GetFullPath());
+
+      //Note: Using a variant of wstring conversion that seems to work more reliably when there are special characters present in the path.
+      std::string cache_path = wstring_to_string(wxFileName(cache_folder).GetFullPath().ToStdWstring());
+
       std::cout << "cache path = " << cache_path << std::endl;
 
       std::cout << "Creating pipeline object with following devices" << std::endl;

--- a/mod-openvino/OVNoiseSuppression.cpp
+++ b/mod-openvino/OVNoiseSuppression.cpp
@@ -25,6 +25,8 @@
 #include "LoadEffects.h"
 #include <future>
 
+#include "OVStringUtils.h"
+
 #include <openvino/openvino.hpp>
 
 const ComponentInterfaceSymbol EffectOVNoiseSuppression::Symbol{ XO("OpenVINO Noise Suppression") };
@@ -135,7 +137,7 @@ void EffectOVNoiseSuppression::CompileNoiseSuppression(ov::CompiledModel& compil
    std::cout << "Using model path = " << model_path << std::endl;
 
    FilePath cache_folder = FileNames::MkDir(wxFileName(FileNames::DataDir(), wxT("openvino-model-cache")).GetFullPath());
-   std::string cache_path = audacity::ToUTF8(wxFileName(cache_folder).GetFullPath());
+   std::string cache_path = wstring_to_string(wxFileName(cache_folder).GetFullPath().ToStdWstring());
 
    ov::Core core;
 

--- a/mod-openvino/OVStringUtils.h
+++ b/mod-openvino/OVStringUtils.h
@@ -1,0 +1,33 @@
+// Copyright (C) 2024 Intel Corporation
+// SPDX-License-Identifier: GPL-3.0-only
+
+#pragma once
+#include <string>
+#ifdef _WIN32 
+#include <windows.h>
+#else
+#include <codecvt>
+#include <locale>
+#endif
+
+static inline std::string FullPath(std::string base_dir, std::string filename)
+{
+#ifdef WIN32
+   const std::string os_sep = "\\";
+#else
+   const std::string os_sep = "/";
+#endif
+   return base_dir + os_sep + filename;
+}
+
+static inline std::string wstring_to_string(const std::wstring& wstr) {
+#ifdef _WIN32 
+   int size_needed = WideCharToMultiByte(CP_ACP, 0, &wstr[0], (int)wstr.size(), NULL, 0, NULL, NULL);
+   std::string strTo(size_needed, 0);
+   WideCharToMultiByte(CP_ACP, 0, &wstr[0], (int)wstr.size(), &strTo[0], size_needed, NULL, NULL);
+   return strTo;
+#else 
+   std::wstring_convert<std::codecvt_utf8<wchar_t>> wstring_decoder;
+   return wstring_decoder.to_bytes(wstr);
+#endif 
+}

--- a/mod-openvino/OVWhisperTranscription.cpp
+++ b/mod-openvino/OVWhisperTranscription.cpp
@@ -35,6 +35,8 @@
 #include "FileNames.h"
 #include "CodeConversions.h"
 
+#include "OVStringUtils.h"
+
 #include <openvino/openvino.hpp>
 
 static const std::map<std::string, std::pair<int, std::string>> g_lang = {
@@ -674,7 +676,9 @@ bool EffectOVWhisperTranscription::Whisper(std::vector<float>& mono_samples, Lab
       .GetFullPath());
 
    FilePath cache_folder = FileNames::MkDir(wxFileName(FileNames::DataDir(), wxT("openvino-model-cache")).GetFullPath());
-   std::string cache_path = audacity::ToUTF8(wxFileName(cache_folder).GetFullPath());
+
+   //Note: Using a variant of wstring conversion that seems to work more reliably when there are special characters present in the path.
+   std::string cache_path = wstring_to_string(wxFileName(cache_folder).GetFullPath().ToStdWstring());
 
    std::string smode = mSupportedModes[m_modeSelectionChoice];
    std::cout << "Mode = " << smode << std::endl;


### PR DESCRIPTION
This PR should resolve issues such as this one: https://github.com/intel/openvino-plugins-ai-audacity/issues/45

There is a bit of an inconsistency between how OpenVINO handles UTF-8 paths (that contain special characters) between ov::cache_dir API, and core.read_model API's. This is highlighted by this bug report: https://github.com/openvinotoolkit/openvino/issues/23072

As a workaround, a specific flavor of wstring-to-string conversion is used to generate the cache_path ultimately passed to ov::Core set_property API. 