### PR TITLE
whisper: Add support for other models (and other fun!)

### DIFF
--- a/mod-openvino/OVWhisperTranscription.h
+++ b/mod-openvino/OVWhisperTranscription.h
@@ -10,6 +10,11 @@ class wxString;
 class wxChoice;
 class wxCheckBox;
 class LabelTrack;
+class wxTextCtrl;
+class wxSizer;
+
+#include <wx/weakref.h>
+
 
 class EffectOVWhisperTranscription final : public StatefulEffect
 {
@@ -39,6 +44,8 @@ public:
    bool UpdateProgress(double perc);
    bool _EncoderBegin();
 
+   void OnAdvancedCheckboxChanged(wxCommandEvent& evt);
+
 private:
    // EffectFindCliping implementation
 
@@ -50,8 +57,10 @@ private:
    //const EffectParameterMethods& Parameters() const override;
    bool ProcessStereoToMono(sampleCount& curTime, sampleCount totalTime, WaveTrack& track);
 
-   bool ProcessWhisper(WaveTrack* mono, LabelTrack* lt);
-   bool Whisper(std::vector<float>& mono_samples, LabelTrack* lt, double start_time);
+   bool ProcessWhisper(WaveTrack* mono, LabelTrack* lt0, LabelTrack* lt1);
+   bool Whisper(std::vector<float>& mono_samples, LabelTrack* lt0, LabelTrack* lt1, double start_time);
+
+   wxWeakRef<wxWindow> mUIParent{};
 
    enum control
    {
@@ -59,7 +68,7 @@ private:
       ID_Type_Model = 10001,
       ID_Type_Mode = 10002,
       ID_Type_Language = 10003,
-      ID_Type_PerWord = 10004,
+      ID_Type_AdvancedCheckbox = 10004,
    };
 
    wxChoice* mTypeChoiceDeviceCtrl;
@@ -94,6 +103,25 @@ private:
    std::mutex mMutex;
    bool mIsCancelled = false;
 
-  
+   void show_or_hide_advanced_options();
 
+   //advanced options
+   wxCheckBox* mShowAdvancedOptionsCheckbox;
+   bool mbAdvanced = false;
+
+   wxSizer* advancedSizer = nullptr;
+
+   int mMaxTextSegLength = 0;
+   wxTextCtrl* mMaxTextSegLengthCtrl = nullptr;
+
+   std::string mInitialPrompt = "";
+   wxTextCtrl* mInitialPromptCtrl = nullptr;
+
+   int mBeamSize = 1;
+   wxTextCtrl* mBeamSizeCtrl = nullptr;
+
+   int mBestOf = 1;
+   wxTextCtrl* mBestOfCtrl = nullptr;
+
+   DECLARE_EVENT_TABLE()
 };


### PR DESCRIPTION
1. Populate the selectable drop-down list of whisper models by checking the contents of the 'openvino-models' folder. This will make it easier to configure the set of models at install time, or even post-install.
2. Add experimental support for small.en-tdrz model, which has built-in support for 'speaker-turn' based diarization. If this model is enabled, the analyzer will populate 2 label tracks, and switch between them for each [SPEAKER TURN] tag encountered.
3. Expose some 'advanced' options to the settings dialog.