### PR TITLE
Music Separation Enhancements

### DIFF
--- a/doc/build_doc/linux/README.md
+++ b/doc/build_doc/linux/README.md
@@ -272,6 +272,20 @@ unzip whisper.cpp-openvino-models/ggml-small.en-tdrz-models.zip -d openvino-mode
 # Now that the required models are extracted, feel free to delete the cloned 'whisper.cpp-openvino-models' directory.
 rm -rf whisper.cpp-openvino-models
 
+#********************
+#* Music Separation *
+#********************
+
+# clone the HF repo
+git clone https://huggingface.co/Intel/demucs-openvino
+
+# Copy the demucs OpenVINO IR files
+cp demucs-openvino/htdemucs_v4.bin openvino-models
+cp demucs-openvino/htdemucs_v4.xml openvino-models
+
+# Now that the required models are extracted, feel free to delete the cloned 'demucs-openvino' directory.
+rm -rf demucs-openvino
+
 # TODO: Add remaining models!
 ```
 After the above sequence of commands you should have a single ```openvino-models``` folder, which you can copy to /usr/local/lib like this:

--- a/doc/build_doc/windows/README.md
+++ b/doc/build_doc/windows/README.md
@@ -262,6 +262,20 @@ tar -xf whisper.cpp-openvino-models\ggml-small.en-tdrz-models.zip -C openvino-mo
 :: Now that the required models are extracted, feel free to delete the cloned 'whisper.cpp-openvino-models' directory.
 rmdir whisper.cpp-openvino-models /s /q
 
+::********************
+::* Music Separation *
+::********************
+
+:: clone the HF repo
+git clone https://huggingface.co/Intel/demucs-openvino
+
+:: Copy the demucs OpenVINO IR files
+copy /y demucs-openvino\htdemucs_v4.bin openvino-models
+copy /y demucs-openvino\htdemucs_v4.xml openvino-models
+
+:: Now that the required models are extracted, feel free to delete the cloned 'demucs-openvino' directory.
+rmdir demucs-openvino /s /q
+
 :: TODO: Add remaining models!
 ```
 Now that you have generated the ```openvino-models``` directory, copy it to the same folder as ```Audacity.exe``` (e.g. ```audacity-build\bin\Release\```).

--- a/mod-openvino/OVMusicSeparation.h
+++ b/mod-openvino/OVMusicSeparation.h
@@ -8,6 +8,9 @@
 
 class WaveTrack;
 class wxChoice;
+class wxCheckBox;
+class wxTextCtrl;
+class wxSizer;
 
 class EffectOVMusicSeparation final : public StatefulEffect
 {
@@ -39,6 +42,8 @@ class EffectOVMusicSeparation final : public StatefulEffect
          EffectSettingsAccess& access, const EffectOutputs* pOutputs) override;
       bool TransferDataToWindow(const EffectSettings& settings) override;
 
+      void OnAdvancedCheckboxChanged(wxCommandEvent& evt);
+
    protected:
 
       wxChoice* mTypeChoiceDeviceCtrl;
@@ -49,6 +54,7 @@ class EffectOVMusicSeparation final : public StatefulEffect
        enum control
        {
           ID_Type = 10000,
+          ID_Type_AdvancedCheckbox
        };
 
        std::vector< std::string > mSupportedDevices;
@@ -60,5 +66,15 @@ class EffectOVMusicSeparation final : public StatefulEffect
 
        wxWeakRef<wxWindow> mUIParent{};
 
+       wxCheckBox* mShowAdvancedOptionsCheckbox;
+
+       int mNumberOfShifts = 1;
+       wxTextCtrl* mNumberOfShiftsCtrl = nullptr;
+
+       void show_or_hide_advanced_options();
+       wxSizer* advancedSizer = nullptr;
+       bool mbAdvanced = false;
+
+       DECLARE_EVENT_TABLE()
 };
 

--- a/mod-openvino/htdemucs.cpp
+++ b/mod-openvino/htdemucs.cpp
@@ -276,9 +276,7 @@ namespace ovdemucs
             std::memcpy(pXTTensor, xt.data_ptr(), xt.numel() * xt.element_size());
 
             static int inferencei = 0;
-            std::cout << "running openvino inference " << inferencei++ << std::endl;
             inferRequest.infer();
-            std::cout << "running openvino inference done.." << std::endl;
 
             const ov::Tensor& x_out_tensor = inferRequest.get_tensor(outputsNames[0]);
             const ov::Tensor& xt_out_tensor = inferRequest.get_tensor(outputsNames[1]);
@@ -901,6 +899,7 @@ namespace ovdemucs
                          float* &pOut1,
                          float* &pOut2,
                          float* &pOut3,
+                         int64_t num_shifts,
                          ProgressUpdate fn,
                          void* progress_update_user)
     {
@@ -916,7 +915,7 @@ namespace ovdemucs
          //dump_tensor(mix_infer, "my_cmix_after_mean_std.raw");
          //std::cout << "mix_infer.sizes() = " << mix_infer.sizes() << std::endl;
 
-         if (!_apply_model_0(mix_infer, _priv->_sources, 2, true, 0.25, 1.0, 2))
+         if (!_apply_model_0(mix_infer, _priv->_sources, num_shifts, true, 0.25, 1.0, 2))
          {
             return false;
          }

--- a/mod-openvino/htdemucs.h
+++ b/mod-openvino/htdemucs.h
@@ -26,10 +26,11 @@ namespace ovdemucs
         //will return true if processing completed, false if processing was cancelled, and
         // will throw an exception upon error.
         bool Apply(float* pIn, int64_t nsamples,
-           float* &pOut0,
-           float* &pOut1,
-           float* &pOut2,
-           float* &pOut3,
+           float*& pOut0,
+           float*& pOut1,
+           float*& pOut2,
+           float*& pOut3,
+           int64_t num_shifts = 2,
            ProgressUpdate fn = nullptr,
            void* progress_update_user = nullptr);
 


### PR DESCRIPTION
1. Change to use htdemucs_v4 model in IR format (previously used .onnx)
2. Expose 'shifts' as an advanced parameter. Note that previously this defaulted to 2, but in the few tracks that I tested with a value of 1 gives identical results, but with 2x performance (as this decreases total number of inferences by 2). Anyway, I wanted to at least give the ability to set this value as (theoretically) higher number of shifts can produce better output.
3. Updated build instructions for Windows & Linux to grab these models from HF.