### PR TITLE
Opencl dll fix

### DIFF
--- a/tools/windows/audacity_ai_plugins.iss
+++ b/tools/windows/audacity_ai_plugins.iss
@@ -83,6 +83,9 @@ Source: "{#BUILD_FOLDER}\whisper-build-no-avx\installed\bin\whisper.dll"; DestDi
 ; Audacity module
 Source: "{#BUILD_FOLDER}\audacity-build\{#AUDACITY_BUILD_CONFIG}\modules\mod-openvino.dll"; DestDir: "{app}\modules"; Flags: ignoreversion
 
+; OpenCL DLL
+Source: "{#OPENCL_SDK_DIR}\bin\OpenCL.dll"; DestDir: "{app}"; Flags: ignoreversion
+
 Source: "module_preferences.bmp"; Flags: dontcopy
 
 ; NOTE: Don't use "Flags: ignoreversion" on any shared system files

--- a/tools/windows/package.bat
+++ b/tools/windows/package.bat
@@ -36,6 +36,11 @@ IF "%AI_PLUGIN_REPO_SOURCE_FOLDER%"=="" (
     exit /b
 )
 
+IF "%OPENCL_SDK_DIR%"=="" (
+    echo OPENCL_SDK_DIR is not set. Exiting.
+    exit /b
+)
+
 
 
 set "bat_path=%~dp0"
@@ -50,6 +55,7 @@ iscc /O+ %audacity_ai_plugins_iss_path% ^
   /DAUDACITY_BUILD_CONFIG=%AUDACITY_BUILD_CONFIG% ^
   /DAI_PLUGIN_VERSION=%AI_PLUGIN_VERSION% ^
   /DAI_PLUGIN_REPO_SOURCE_FOLDER=%AI_PLUGIN_REPO_SOURCE_FOLDER% ^
+  /DOPENCL_SDK_DIR=%OPENCL_SDK_DIR% ^
   /O%BUILD_FOLDER% ^
   /Faudacity-win-%AI_PLUGIN_VERSION%-64bit-OpenVINO-AI-Plugins
   

--- a/tools/windows/set_env.bat
+++ b/tools/windows/set_env.bat
@@ -17,7 +17,7 @@ set AUDACITY_BUILD_LEVEL=2
 set AUDACITY_BUILD_CONFIG=RelWithDebInfo
 
 :: The version that we will pass to inno setup as the app version.
-set AI_PLUGIN_VERSION=v3.5.1-R2.1
+set AI_PLUGIN_VERSION=v3.5.1-R2.2
 
 set AI_PLUGIN_REPO_SOURCE_FOLDER=%bat_path%\..\..\
 echo AI_PLUGIN_REPO_SOURCE_FOLDER=%AI_PLUGIN_REPO_SOURCE_FOLDER%


### PR DESCRIPTION
It seems that some users do not have OpenCL.dll present on their Windows systems by default. So, package this with the installer.

Resolves these issues: 
https://github.com/intel/openvino-plugins-ai-audacity/issues/188 
https://github.com/intel/openvino-plugins-ai-audacity/issues/141