### PR TITLE
Update CMakeList.txt to fix compiling errors

### DIFF
--- a/mod-openvino/CMakeLists.txt
+++ b/mod-openvino/CMakeLists.txt
@@ -77,7 +77,7 @@ audacity_module( ${TARGET} "${SOURCES}" "${LIBRARIES}" "" "" )
 
 if(MSVC)
    target_compile_options(${TARGET} PRIVATE
-   /analyze /sdl /Gy /DYNAMICBASE /GS /D _SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING
+   /analyze /sdl /Gy /DYNAMICBASE /GS /D_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING /D_CRT_SECURE_NO_WARNINGS
    )
 endif()
 


### PR DESCRIPTION
To fix the errors (like the below) caused by security warning

```
C:\Users\Local_Admin\.conan2\p\wxwid0366c4356bdc4\p\include\wx\wxcrt.h(925,68): error C4996: '_wgetenv': This function
or variable may be unsafe. Consider using _wdupenv_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See
online help for details. [C:\MTL\Intel_DNS\openvino-plugins-ai-audacity\tools\windows\BuildArtifacts-20240828_115140\au
dacity-build\modules\etc\mod-openvino\mod-openvino.vcxproj]
```
