### PR TITLE
cmake: get cpp-httplib libraries from pkgconf

### DIFF
--- a/mod-openvino/CMakeLists.txt
+++ b/mod-openvino/CMakeLists.txt
@@ -27,6 +27,8 @@ include_directories( ittutils )
 
 find_package(OpenCL REQUIRED)
 
+pkg_search_module(CPPHTTPLIB REQUIRED cpp-httplib)
+
 add_subdirectory(musicgen)
 include_directories(musicgen)
 
@@ -88,6 +90,7 @@ set( LIBRARIES
       openvino::runtime
 	   OpenCL::OpenCL
       ${TORCH_LIBRARIES}
+      ${CPPHTTPLIB_LIBRARIES}
       ${whisper}
 )
 


### PR DESCRIPTION
openvino-audacity requires libcpp-httlib, but doesn't look it up in CMake. REQUIRE it, so that we fail at configuration time if it's not available, and properly pass -l options when it is.

without this, we fail with:

```
[ 98%] Building CXX object modules/mod-openvino/CMakeFiles/mod-openvino.dir/OVWhisperTranscription.cpp.o
[ 98%] Linking CXX shared module ../../RelWithDebInfo/lib/audacity/modules/mod-openvino.so
/usr/bin/ld: cannot find -lhttplib: No such file or directory
collect2: error: ld returned 1 exit status
```