### PR TITLE
Group all tools under a single submenu

### DIFF
--- a/mod-openvino/OVMusicGenerationLLM.cpp
+++ b/mod-openvino/OVMusicGenerationLLM.cpp
@@ -193,7 +193,7 @@ VendorSymbol EffectOVMusicGenerationLLM::GetVendor() const
 // EffectDefinitionInterface implementation
 EffectType EffectOVMusicGenerationLLM::GetType() const
 {
-   return EffectTypeGenerate;
+   return EffectTypeProcess;
 }
 
 bool EffectOVMusicGenerationLLM::DoEffect(

--- a/mod-openvino/OVWhisperTranscription.cpp
+++ b/mod-openvino/OVWhisperTranscription.cpp
@@ -418,7 +418,7 @@ VendorSymbol EffectOVWhisperTranscription::GetVendor() const
 
 EffectType EffectOVWhisperTranscription::GetType() const
 {
-   return EffectTypeAnalyze;
+   return EffectTypeProcess;
 }
 
 bool EffectOVWhisperTranscription::Process(EffectInstance&, EffectSettings&)


### PR DESCRIPTION
Currently, OpenVINO tools are scattered across multiple menus:

- Music Generator appears under /Generate
- Noise Suppression, Music Separation, and Super Resolution appear under /Effect
- Whisper appears under /Analyze

While this is consistent with each tool's function, it makes them harder to discover and use.

This PR reorganizes this for a better user experience: all OpenVINO-related entries are now grouped under a single submenu /Effect/OpenVINO
