### PR TITLE
Add Model Cards to Model Manager UI

### DIFF
--- a/mod-openvino/CMakeLists.txt
+++ b/mod-openvino/CMakeLists.txt
@@ -97,6 +97,7 @@ set( SOURCES
       OVModelManager.h
       OVModelManager.cpp
       OVModelManagerPopulation.cpp
+      model_md_card_info.h
 )
 
 set( LIBRARIES

--- a/mod-openvino/OVModelManagerPopulation.cpp
+++ b/mod-openvino/OVModelManagerPopulation.cpp
@@ -419,7 +419,7 @@ static std::shared_ptr< OVModelManager::ModelCollection > populate_whisper()
          "Distil-Whisper Large V3 (FP16)",
          "distil-whisper-large-v3-fp16-ov",
          "https://huggingface.co/OpenVINO/distil-whisper-large-v3-fp16-ov/resolve/main/",
-         "FP16-quantized version of Distil=Whisper-Large-V3. See Quantization / Model Variant Guides below for more information."
+         "FP16-quantized version of Distil-Whisper-Large-V3. See Quantization / Model Variant Guides below for more information."
       },
       {
          "Distil-Whisper Large V3 (INT8)",

--- a/mod-openvino/OVModelManagerPopulation.cpp
+++ b/mod-openvino/OVModelManagerPopulation.cpp
@@ -1,4 +1,5 @@
 #include "OVModelManager.h"
+#include "model_md_card_info.h"
 
 static std::shared_ptr< OVModelManager::ModelCollection > populate_music_separation()
 {
@@ -12,7 +13,7 @@ static std::shared_ptr< OVModelManager::ModelCollection > populate_music_separat
       {
          std::shared_ptr<OVModelManager::ModelInfo> demucs_model_info = std::make_shared<OVModelManager::ModelInfo>();
          demucs_model_info->model_name = "Demucs v4";
-         demucs_model_info->info = "Demucs-v4 is a state-of-the-art music source separation model that can separate drums, bass, vocals, and other stems from any song.";
+         demucs_model_info->info = music_separation_demucs_v4;
          demucs_model_info->baseUrl = "";
          demucs_model_info->relative_path = relative_path + "htdemucs_v4";
          demucs_model_info->fileList = fileList;
@@ -22,7 +23,7 @@ static std::shared_ptr< OVModelManager::ModelCollection > populate_music_separat
       {
          std::shared_ptr<OVModelManager::ModelInfo> demucs_model_info = std::make_shared<OVModelManager::ModelInfo>();
          demucs_model_info->model_name = "Demucs v4 FT Drums";
-         demucs_model_info->info = "A fine-tuned variant of Demucs-v4 that gives slightly better results for drums";
+         demucs_model_info->info = music_separation_demucs_v4_ft_drums;
          demucs_model_info->baseUrl = "";
          demucs_model_info->relative_path = relative_path + "htdemucs_v4_ht_drums";
          demucs_model_info->fileList = fileList;
@@ -32,7 +33,7 @@ static std::shared_ptr< OVModelManager::ModelCollection > populate_music_separat
       {
          std::shared_ptr<OVModelManager::ModelInfo> demucs_model_info = std::make_shared<OVModelManager::ModelInfo>();
          demucs_model_info->model_name = "Demucs v4 FT Bass";
-         demucs_model_info->info = "A fine-tuned variant of Demucs-v4 that gives slightly better results for bass";
+         demucs_model_info->info = music_separation_demucs_v4_ft_bass;
          demucs_model_info->baseUrl = "";
          demucs_model_info->relative_path = relative_path + "htdemucs_v4_ht_bass";
          demucs_model_info->fileList = fileList;
@@ -42,7 +43,7 @@ static std::shared_ptr< OVModelManager::ModelCollection > populate_music_separat
       {
          std::shared_ptr<OVModelManager::ModelInfo> demucs_model_info = std::make_shared<OVModelManager::ModelInfo>();
          demucs_model_info->model_name = "Demucs v4 FT Other Instruments";
-         demucs_model_info->info = "A fine-tuned variant of Demucs-v4 that gives slightly better results for 'other instruments'";
+         demucs_model_info->info = music_separation_demucs_v4_ft_other;
          demucs_model_info->baseUrl = "";
          demucs_model_info->relative_path = relative_path + "htdemucs_v4_ht_other";
          demucs_model_info->fileList = fileList;
@@ -52,7 +53,7 @@ static std::shared_ptr< OVModelManager::ModelCollection > populate_music_separat
       {
          std::shared_ptr<OVModelManager::ModelInfo> demucs_model_info = std::make_shared<OVModelManager::ModelInfo>();
          demucs_model_info->model_name = "Demucs v4 FT Vocals";
-         demucs_model_info->info = "A fine-tuned variant of Demucs-v4 that gives slightly better results for vocals";
+         demucs_model_info->info = music_separation_demucs_v4_ft_vocals;
          demucs_model_info->baseUrl = "";
          demucs_model_info->relative_path = relative_path + "htdemucs_v4_ht_vocals";
          demucs_model_info->fileList = fileList;
@@ -62,7 +63,7 @@ static std::shared_ptr< OVModelManager::ModelCollection > populate_music_separat
       {
          std::shared_ptr<OVModelManager::ModelInfo> demucs_model_info = std::make_shared<OVModelManager::ModelInfo>();
          demucs_model_info->model_name = "Demucs v4 6s";
-         demucs_model_info->info = "A 6-stem variant of Demucs v4 that can separate drums, bass, vocals, guitar, piano, and others";
+         demucs_model_info->info = music_separation_demucs_v4_6s;
          demucs_model_info->baseUrl = "";
          demucs_model_info->relative_path = relative_path + "htdemucs_v4_6s";
          demucs_model_info->fileList = fileList;
@@ -79,7 +80,7 @@ static std::shared_ptr< OVModelManager::ModelCollection > populate_music_separat
       {
          std::shared_ptr<OVModelManager::ModelInfo> mel_model_info = std::make_shared<OVModelManager::ModelInfo>();
          mel_model_info->model_name = "MelBandRoformer Vocals (@KimberleyJensen)";
-         mel_model_info->info = "A MelBandRoformer-based vocal extraction model. Trained by @KimberlyJenson";
+         mel_model_info->info = music_separation_mel_vocals_kimberley_jenson;
          mel_model_info->baseUrl = "";
          mel_model_info->relative_path = relative_path + "melband_roformer_kimberley_jenson";
          mel_model_info->fileList = fileList;
@@ -89,7 +90,7 @@ static std::shared_ptr< OVModelManager::ModelCollection > populate_music_separat
       {
          std::shared_ptr<OVModelManager::ModelInfo> mel_model_info = std::make_shared<OVModelManager::ModelInfo>();
          mel_model_info->model_name = "MelBandRoformer Crowd (@aufr33 & @viperx)";
-         mel_model_info->info = "A MelBandRoformer-based crowd extraction model.";
+         mel_model_info->info = music_separation_mel_crowd_aufr33_viperx;
          mel_model_info->baseUrl = "";
          mel_model_info->relative_path = relative_path + "melband_roformer_crowd";
          mel_model_info->fileList = fileList;
@@ -104,7 +105,7 @@ static std::shared_ptr< OVModelManager::ModelCollection > populate_music_separat
       {
          std::shared_ptr<OVModelManager::ModelInfo> mdx_model_info = std::make_shared<OVModelManager::ModelInfo>();
          mdx_model_info->model_name = "MDX23C Drum Separation (@jarredou)";
-         mdx_model_info->info = "A Drum Separation model that can produce 5 stems: kick, snare, toms, hi-hat, cymbals";
+         mdx_model_info->info = music_separation_msdx23c_drum_sep_jarredou;
          mdx_model_info->baseUrl = "";
          mdx_model_info->relative_path = relative_path + "drumsep_jarredou_mdx23c";
          mdx_model_info->fileList = fileList;
@@ -131,7 +132,7 @@ static std::shared_ptr< OVModelManager::ModelCollection > populate_reverb_remova
       {
          std::shared_ptr<OVModelManager::ModelInfo> mel_model_info = std::make_shared<OVModelManager::ModelInfo>();
          mel_model_info->model_name = "MelBandRoformer Dereverb Mono (@anvuew)";
-         mel_model_info->info = "A MelBandRoformer-based Reverb Removal model that works well with spoken audio";
+         mel_model_info->info = reverb_removal_mel_band_dereverb_mono_anvuew;
          mel_model_info->baseUrl = "";
          mel_model_info->relative_path = relative_path + "mel_band_roformer_mono_anvuew";
          mel_model_info->fileList = fileList;
@@ -155,7 +156,7 @@ static std::shared_ptr< OVModelManager::ModelCollection > populate_music_restora
       {
          std::shared_ptr<OVModelManager::ModelInfo> mel_model_info = std::make_shared<OVModelManager::ModelInfo>();
          mel_model_info->model_name = "Apollo MP3 Restore (@JusperLee)";
-         mel_model_info->info = "A Apollo-based lossy restoration model that works well with low-bitrate MP3s";
+         mel_model_info->info = music_restoration_apollo_mp3_jusperlee;
          mel_model_info->baseUrl = "";
          mel_model_info->relative_path = relative_path + "apollo_jusperlee";
          mel_model_info->fileList = fileList;
@@ -165,7 +166,7 @@ static std::shared_ptr< OVModelManager::ModelCollection > populate_music_restora
       {
          std::shared_ptr<OVModelManager::ModelInfo> mel_model_info = std::make_shared<OVModelManager::ModelInfo>();
          mel_model_info->model_name = "Apollo Universal Restore (@Lew)";
-         mel_model_info->info = "A Apollo-based lossy restoration model that works well, universally (TODO)";
+         mel_model_info->info = music_restoration_apollo_universal_lew;
          mel_model_info->baseUrl = "";
          mel_model_info->relative_path = relative_path + "apollo_universal";
          mel_model_info->fileList = fileList;
@@ -210,7 +211,7 @@ static std::shared_ptr< OVModelManager::ModelCollection > populate_music_generat
       {
          std::shared_ptr<OVModelManager::ModelInfo> model = std::make_shared<OVModelManager::ModelInfo>();
          model->model_name = "Small Mono (FP16)";
-         model->info = "FP16-quantized variant of facebook/musicgen-small model. This is a mono model, therefore it will produce a mono track.";
+         model->info = music_generation_music_gen_small_mono_fp16;
          model->baseUrl = baseUrl;
          model->relative_path = "musicgen";
          model->dependencies.push_back(common);
@@ -226,7 +227,7 @@ static std::shared_ptr< OVModelManager::ModelCollection > populate_music_generat
       {
          std::shared_ptr<OVModelManager::ModelInfo> model = std::make_shared<OVModelManager::ModelInfo>();
          model->model_name = "Small Mono (INT8)";
-         model->info = "INT8-quantized variant of facebook/musicgen-small model. This is a mono model, therefore it will produce a mono track.";
+         model->info = music_generation_music_gen_small_mono_int8;
          model->baseUrl = baseUrl;
          model->relative_path = "musicgen";
          model->dependencies.push_back(common);
@@ -254,7 +255,7 @@ static std::shared_ptr< OVModelManager::ModelCollection > populate_music_generat
       {
          std::shared_ptr<OVModelManager::ModelInfo> model = std::make_shared<OVModelManager::ModelInfo>();
          model->model_name = "Small Stereo (FP16)";
-         model->info = "FP16-quantized variant of facebook/musicgen-stereo-small model. This is a stereo model, therefore it will produce a stereo track.";
+         model->info = music_generation_music_gen_small_stereo_fp16;
          model->baseUrl = baseUrl;
          model->relative_path = "musicgen";
          model->dependencies.push_back(common);
@@ -270,7 +271,7 @@ static std::shared_ptr< OVModelManager::ModelCollection > populate_music_generat
       {
          std::shared_ptr<OVModelManager::ModelInfo> model = std::make_shared<OVModelManager::ModelInfo>();
          model->model_name = "Small Stereo (INT8)";
-         model->info = "INT8-quantized variant of facebook/musicgen-stereo-small model. This is a stereo model, therefore it will produce a stereo track.";
+         model->info = music_generation_music_gen_small_stereo_int8;
          model->baseUrl = baseUrl;
          model->relative_path = "musicgen";
          model->dependencies.push_back(common);
@@ -298,7 +299,7 @@ static std::shared_ptr< OVModelManager::ModelCollection > populate_music_generat
       {
          std::shared_ptr<OVModelManager::ModelInfo> model = std::make_shared<OVModelManager::ModelInfo>();
          model->model_name = "Medium Mono (FP16)";
-         model->info = "FP16-quantized variant of facebook/musicgen-medium model. This is a mono model, therefore it will produce a mono track.";
+         model->info = music_generation_music_gen_medium_mono_fp16;
          model->baseUrl = baseUrl;
          model->relative_path = "musicgen";
          model->dependencies.push_back(common);
@@ -314,7 +315,7 @@ static std::shared_ptr< OVModelManager::ModelCollection > populate_music_generat
       {
          std::shared_ptr<OVModelManager::ModelInfo> model = std::make_shared<OVModelManager::ModelInfo>();
          model->model_name = "Medium Mono (INT8)";
-         model->info = "INT8-quantized variant of facebook/musicgen-medium model. This is a mono model, therefore it will produce a mono track.";
+         model->info = music_generation_music_gen_medium_mono_int8;
          model->baseUrl = baseUrl;
          model->relative_path = "musicgen";
          model->dependencies.push_back(common);
@@ -335,158 +336,138 @@ struct WhisperInfo
    std::string ui_name;
    std::string relative_path;
    std::string base_url;
+   std::string quick_description;
 };
 
 static std::shared_ptr< OVModelManager::ModelCollection > populate_whisper()
 {
-   const std::vector< WhisperInfo> whisper_model_info
+   const std::vector<WhisperInfo> whisper_model_infos
    {
       {
          "Whisper Base (FP16)",
          "whisper-base-fp16-ov",
-         "https://huggingface.co/OpenVINO/whisper-base-fp16-ov/resolve/main/"
+         "https://huggingface.co/OpenVINO/whisper-base-fp16-ov/resolve/main/",
+         "FP16-quantized version of Whisper-Base. See Quantization / Model Variant Guides below for more information."
       },
       {
          "Whisper Base (INT8)",
          "whisper-base-int8-ov",
-         "https://huggingface.co/OpenVINO/whisper-base-int8-ov/resolve/main/"
+         "https://huggingface.co/OpenVINO/whisper-base-int8-ov/resolve/main/",
+         "INT8-quantized version of Whisper-Base. See Quantization / Model Variant Guides below for more information."
       },
       {
          "Whisper Base (INT4)",
          "whisper-base-int4-ov",
-         "https://huggingface.co/OpenVINO/whisper-base-int4-ov/resolve/main/"
+         "https://huggingface.co/OpenVINO/whisper-base-int4-ov/resolve/main/",
+         "INT4-quantized version of Whisper-Base. See Quantization / Model Variant Guides below for more information."
       },
       {
          "Whisper Medium (FP16)",
          "whisper-medium-fp16-ov",
-         "https://huggingface.co/OpenVINO/whisper-medium-fp16-ov/resolve/main/"
+         "https://huggingface.co/OpenVINO/whisper-medium-fp16-ov/resolve/main/",
+         "FP16-quantized version of Whisper-Medium. See Quantization / Model Variant Guides below for more information."
       },
       {
          "Whisper Medium (INT8)",
          "whisper-medium-int8-ov",
-         "https://huggingface.co/OpenVINO/whisper-medium-int8-ov/resolve/main/"
+         "https://huggingface.co/OpenVINO/whisper-medium-int8-ov/resolve/main/",
+         "INT8-quantized version of Whisper-Medium. See Quantization / Model Variant Guides below for more information."
       },
       {
          "Whisper Medium (INT4)",
          "whisper-medium-int4-ov",
-         "https://huggingface.co/OpenVINO/whisper-medium-int4-ov/resolve/main/"
+         "https://huggingface.co/OpenVINO/whisper-medium-int4-ov/resolve/main/",
+         "INT4-quantized version of Whisper-Medium. See Quantization / Model Variant Guides below for more information."
       },
       {
          "Whisper Large V2 (FP16)",
          "whisper-large-v2-fp16-ov",
-         "" //Not yet on HF. Hopefully soon!
+         "", //Not yet on HF. Hopefully soon!
+         "FP16-quantized version of Whisper-Large-V2. See Quantization / Model Variant Guides below for more information."
       },
       {
          "Whisper Large V2 (INT8)",
          "whisper-large-v2-int8-ov",
-         "" //Not yet on HF. Hopefully soon!
+         "", //Not yet on HF. Hopefully soon!
+         "INT8-quantized version of Whisper-Large-V2. See Quantization / Model Variant Guides below for more information."
       },
       {
          "Whisper Large V2 (INT4)",
          "whisper-large-v2-int4-ov",
-         "" //Not yet on HF. Hopefully soon!
+         "", //Not yet on HF. Hopefully soon!
+         "INT4-quantized version of Whisper-Large-V2. See Quantization / Model Variant Guides below for more information."
       },
       {
          "Whisper Large V3 (FP16)",
          "whisper-large-v3-fp16-ov",
-         "https://huggingface.co/OpenVINO/whisper-large-v3-fp16-ov/resolve/main/"
+         "https://huggingface.co/OpenVINO/whisper-large-v3-fp16-ov/resolve/main/",
+         "FP16-quantized version of Whisper-Large-V3. See Quantization / Model Variant Guides below for more information."
       },
       {
          "Whisper Large V3 (INT8)",
          "whisper-large-v3-int8-ov",
-         "https://huggingface.co/OpenVINO/whisper-large-v3-int8-ov/resolve/main/"
+         "https://huggingface.co/OpenVINO/whisper-large-v3-int8-ov/resolve/main/",
+         "INT8-quantized version of Whisper-Large-V3. See Quantization / Model Variant Guides below for more information."
       },
       {
          "Whisper Large V3 (INT4)",
          "whisper-large-v3-int4-ov",
-         "https://huggingface.co/OpenVINO/whisper-large-v3-int4-ov/resolve/main/"
-      },
-      {
-         "Whisper Large V3 Turbo (FP16)",
-         "whisper-large-v3-turbo-fp16-ov",
-         "" //Not yet on HF. Hopefully soon!
-      },
-      {
-         "Whisper Large V3 Turbo (INT8)",
-         "whisper-large-v3-turbo-int8-ov",
-         "" //Not yet on HF. Hopefully soon!
-      },
-      {
-         "Whisper Large V3 Turbo (INT4)",
-         "whisper-large-v3-turbo-int4-ov",
-         "" //Not yet on HF. Hopefully soon!
-      },
-      {
-         "Distil-Whisper Base (FP16)",
-         "distil-whisper-base-fp16-ov",
-         "" // Distil-Base models on HF are kind of broken... they don't include the _with_past models
-      },
-      {
-         "Distil-Whisper Base (INT8)",
-         "distil-whisper-base-int8-ov",
-         "" // Distil-Base models on HF are kind of broken... they don't include the _with_past models
-      },
-      {
-         "Distil-Whisper Base (INT4)",
-         "distil-whisper-base-int4-ov",
-         "" // Distil-Base models on HF are kind of broken... they don't include the _with_past models
-      },
-      {
-         "Distil-Whisper Medium (FP16)",
-         "distil-whisper-medium-fp16-ov",
-         "" // Distil-Medium models on HF are kind of broken... they don't include the _with_past models
-      },
-      {
-         "Distil-Whisper Medium (INT8)",
-         "distil-whisper-medium-int8-ov",
-         "" // Distil-Medium models on HF are kind of broken... they don't include the _with_past models
-      },
-      {
-         "Distil-Whisper Medium (INT4)",
-         "distil-whisper-medium-int4-ov",
-         "" // Distil-Medium models on HF are kind of broken... they don't include the _with_past models
-      },
-      {
-         "Distil-Whisper Large V2 (FP16)",
-         "distil-whisper-large-v2-fp16-ov",
-         "https://huggingface.co/OpenVINO/distil-whisper-large-v2-fp16-ov/resolve/main/"
-      },
-      {
-         "Distil-Whisper Large V2 (INT8)",
-         "distil-whisper-large-v2-int8-ov",
-         "https://huggingface.co/OpenVINO/distil-whisper-large-v2-int8-ov/resolve/main/"
-      },
-      {
-         "Distil-Whisper Large V2 (INT4)",
-         "distil-whisper-large-v2-int4-ov",
-         "https://huggingface.co/OpenVINO/distil-whisper-large-v2-int4-ov/resolve/main/"
+         "https://huggingface.co/OpenVINO/whisper-large-v3-int4-ov/resolve/main/",
+         "INT4-quantized version of Whisper-Large-V3. See Quantization / Model Variant Guides below for more information."
       },
       {
          "Distil-Whisper Large V3 (FP16)",
          "distil-whisper-large-v3-fp16-ov",
-         "https://huggingface.co/OpenVINO/distil-whisper-large-v3-fp16-ov/resolve/main/"
+         "https://huggingface.co/OpenVINO/distil-whisper-large-v3-fp16-ov/resolve/main/",
+         "FP16-quantized version of Distil=Whisper-Large-V3. See Quantization / Model Variant Guides below for more information."
       },
       {
          "Distil-Whisper Large V3 (INT8)",
          "distil-whisper-large-v3-int8-ov",
-         "https://huggingface.co/OpenVINO/distil-whisper-large-v3-int8-ov/resolve/main/"
+         "https://huggingface.co/OpenVINO/distil-whisper-large-v3-int8-ov/resolve/main/",
+         "INT8-quantized version of Distil-Whisper-Large-V3. See Quantization / Model Variant Guides below for more information."
       },
       {
          "Distil-Whisper Large V3 (INT4)",
          "distil-whisper-large-v3-int4-ov",
-         "https://huggingface.co/OpenVINO/distil-whisper-large-v3-int4-ov/resolve/main/"
+         "https://huggingface.co/OpenVINO/distil-whisper-large-v3-int4-ov/resolve/main/",
+         "INT4-quantized version of Distil-Whisper-Large-V3. See Quantization / Model Variant Guides below for more information."
       },
+      {
+         "Whisper Large V3 Turbo (FP16)",
+         "whisper-large-v3-turbo-fp16-ov",
+         "", //Not yet on HF. Hopefully soon!
+         "FP16-quantized version of Whisper-Large-V3-Turbo. See Quantization / Model Variant Guides below for more information."
+      },
+      {
+         "Whisper Large V3 Turbo (INT8)",
+         "whisper-large-v3-turbo-int8-ov",
+         "", //Not yet on HF. Hopefully soon!
+         "INT8-quantized version of Whisper-Large-V3-Turbo. See Quantization / Model Variant Guides below for more information."
+      },
+      {
+         "Whisper Large V3 Turbo (INT4)",
+         "whisper-large-v3-turbo-int4-ov",
+         "", //Not yet on HF. Hopefully soon!
+         "INT4-quantized version of Whisper-Large-V3-Turbo. See Quantization / Model Variant Guides below for more information."
+      }
    };
 
    auto whisper_collection = std::make_shared< OVModelManager::ModelCollection >();
 
-   for (auto& whisper_model_info : whisper_model_info)
+   for (auto& whisper_model_info : whisper_model_infos)
    {
       std::shared_ptr<OVModelManager::ModelInfo> whisper_info = std::make_shared<OVModelManager::ModelInfo>();
       whisper_info->model_name = whisper_model_info.ui_name;
 
+      std::string info = "<h1>" + whisper_model_info.ui_name + "</h1>\n\n";
+      info += "<p>" + whisper_model_info.quick_description + "</p>";
+
+      // Add the 'general' info from whisper/info.md
+      info += whisper_transcription_info;
+
       //TODO: add some more detailed info here..
-      whisper_info->info = whisper_model_info.ui_name + " TODO: Add more info!";
+      whisper_info->info = info;
 
       whisper_info->baseUrl = whisper_model_info.base_url;
       whisper_info->relative_path = "whisper/" + whisper_model_info.relative_path;
@@ -523,7 +504,7 @@ static std::shared_ptr< OVModelManager::ModelCollection > populate_super_resolut
    {
       std::shared_ptr<OVModelManager::ModelInfo> model = std::make_shared<OVModelManager::ModelInfo>();
       model->model_name = "Basic (General) (FP16)";
-      model->info = "Use for enhancing all types of audio including music and environmental sounds.";
+      model->info = super_resolution_basic_general;
       model->baseUrl = baseUrl;
       model->relative_path = "audiosr";
       model->dependencies.push_back(common);
@@ -535,7 +516,7 @@ static std::shared_ptr< OVModelManager::ModelCollection > populate_super_resolut
    {
       std::shared_ptr<OVModelManager::ModelInfo> model = std::make_shared<OVModelManager::ModelInfo>();
       model->model_name = "Speech (FP16)";
-      model->info = "Optimized for enhancing audio with isolated speech.";
+      model->info = super_resolution_speech;
       model->baseUrl = baseUrl;
       model->relative_path = "audiosr";
       model->dependencies.push_back(common);
@@ -559,7 +540,7 @@ static std::shared_ptr< OVModelManager::ModelCollection > populate_noise_suppres
       {
          std::shared_ptr<OVModelManager::ModelInfo> model = std::make_shared<OVModelManager::ModelInfo>();
          model->model_name = "DeepFilterNet2";
-         model->info = "DeepFilterNet2 model";
+         model->info = noise_suppression_deepfilternet2;
          model->baseUrl = baseUrl;
          model->fileList = { "df_dec.bin", "df_dec.xml", "enc.xml", "enc.bin", "erb_dec.xml", "erb_dec.bin" };
 
@@ -574,7 +555,7 @@ static std::shared_ptr< OVModelManager::ModelCollection > populate_noise_suppres
       {
          std::shared_ptr<OVModelManager::ModelInfo> model = std::make_shared<OVModelManager::ModelInfo>();
          model->model_name = "DeepFilterNet3";
-         model->info = "DeepFilterNet3 model";
+         model->info = noise_suppression_deepfilternet3;
          model->baseUrl = baseUrl;
          model->fileList = { "df_dec.bin", "df_dec.xml", "enc.xml", "enc.bin", "erb_dec.xml", "erb_dec.bin" };
 
@@ -590,7 +571,7 @@ static std::shared_ptr< OVModelManager::ModelCollection > populate_noise_suppres
    {
       std::shared_ptr<OVModelManager::ModelInfo> model = std::make_shared<OVModelManager::ModelInfo>();
       model->model_name = "DenseUNet";
-      model->info = "DenseUNet model";
+      model->info = noise_suppression_denseunet;
       model->baseUrl = "https://storage.openvinotoolkit.org/repositories/open_model_zoo/2023.0/models_bin/1/noise-suppression-denseunet-ll-0001/FP16/";
       model->postUrl = "";
       model->fileList = { "noise-suppression-denseunet-ll-0001.xml", "noise-suppression-denseunet-ll-0001.bin" };

--- a/mod-openvino/model_md_card_info.h
+++ b/mod-openvino/model_md_card_info.h
@@ -1,0 +1,267 @@
+// Auto-generated header containing model card HTML strings
+#pragma once
+
+const char* music_generation_music_gen_medium_mono_fp16 = R"md(
+<h1>Music Gen Medium Mono (FP16)</h1>
+<p>FP16 variant of facebook/musicgen-medium model. This is a mono model, therefore it will produce a mono track.</p>
+<p>Source Model: <a href="https://huggingface.co/facebook/musicgen-medium">facebook/musicgen-medium</a></p>
+<p>For use with <a href="https://github.com/intel/openvino-plugins-ai-audacity">OpenVINO AI Plugins for Audacity</a>, the pytorch models source models were converted to OpenVINO IR format, and stored here: <a href="https://huggingface.co/Intel/musicgen-static-openvino">https://huggingface.co/Intel/musicgen-static-openvino</a> </p>
+<p>License: <a href="https://spdx.org/licenses/CC-BY-NC-4.0">cc-by-nc-4.0</a></p>
+)md";
+
+const char* music_generation_music_gen_medium_mono_int8 = R"md(
+<h1>Music Gen Medium Mono (INT8)</h1>
+<p>INT8-quantized variant of facebook/musicgen-medium model. This is a mono model, therefore it will produce a mono track.</p>
+<p>Source Model: <a href="https://huggingface.co/facebook/musicgen-medium">facebook/musicgen-medium</a></p>
+<p>For use with <a href="https://github.com/intel/openvino-plugins-ai-audacity">OpenVINO AI Plugins for Audacity</a>, the pytorch models source models were converted to OpenVINO IR format, and stored here: <a href="https://huggingface.co/Intel/musicgen-static-openvino">https://huggingface.co/Intel/musicgen-static-openvino</a> </p>
+<p>License: <a href="https://spdx.org/licenses/CC-BY-NC-4.0">cc-by-nc-4.0</a></p>
+)md";
+
+const char* music_generation_music_gen_small_mono_fp16 = R"md(
+<h1>Music Gen Small Mono (FP16)</h1>
+<p>FP16 variant of facebook/musicgen-small model. This is a mono model, therefore it will produce a mono track.</p>
+<p>Source Model: <a href="https://huggingface.co/facebook/musicgen-small">facebook/musicgen-small</a></p>
+<p>For use with <a href="https://github.com/intel/openvino-plugins-ai-audacity">OpenVINO AI Plugins for Audacity</a>, the pytorch models source models were converted to OpenVINO IR format, and stored here: <a href="https://huggingface.co/Intel/musicgen-static-openvino">https://huggingface.co/Intel/musicgen-static-openvino</a> </p>
+<p>License: <a href="https://spdx.org/licenses/CC-BY-NC-4.0">cc-by-nc-4.0</a></p>
+)md";
+
+const char* music_generation_music_gen_small_mono_int8 = R"md(
+<h1>Music Gen Small Mono (INT8)</h1>
+<p>INT8-quantized variant of facebook/musicgen-small model. This is a mono model, therefore it will produce a mono track.</p>
+<p>Source Model: <a href="https://huggingface.co/facebook/musicgen-small">facebook/musicgen-small</a></p>
+<p>For use with <a href="https://github.com/intel/openvino-plugins-ai-audacity">OpenVINO AI Plugins for Audacity</a>, the pytorch models source models were converted to OpenVINO IR format, and stored here: <a href="https://huggingface.co/Intel/musicgen-static-openvino">https://huggingface.co/Intel/musicgen-static-openvino</a> </p>
+<p>License: <a href="https://spdx.org/licenses/CC-BY-NC-4.0">cc-by-nc-4.0</a></p>
+)md";
+
+const char* music_generation_music_gen_small_stereo_fp16 = R"md(
+<h1>Music Gen Small Stereo (FP16)</h1>
+<p>FP16 variant of facebook/musicgen-stereo-small model. This is a stereo model, therefore it will produce a stereo track.</p>
+<p>Source Model: <a href="https://huggingface.co/facebook/musicgen-stereo-small">facebook/musicgen-stereo-small</a></p>
+<p>For use with <a href="https://github.com/intel/openvino-plugins-ai-audacity">OpenVINO AI Plugins for Audacity</a>, the pytorch models source models were converted to OpenVINO IR format, and stored here: <a href="https://huggingface.co/Intel/musicgen-static-openvino">https://huggingface.co/Intel/musicgen-static-openvino</a> </p>
+<p>License: <a href="https://spdx.org/licenses/CC-BY-NC-4.0">cc-by-nc-4.0</a></p>
+)md";
+
+const char* music_generation_music_gen_small_stereo_int8 = R"md(
+<h1>Music Gen Small Stereo (INT8)</h1>
+<p>INT8-quantized variant of facebook/musicgen-stereo-small model. This is a stereo model, therefore it will produce a stereo track.</p>
+<p>Source Model: <a href="https://huggingface.co/facebook/musicgen-stereo-small">facebook/musicgen-stereo-small</a></p>
+<p>For use with <a href="https://github.com/intel/openvino-plugins-ai-audacity">OpenVINO AI Plugins for Audacity</a>, the pytorch models source models were converted to OpenVINO IR format, and stored here: <a href="https://huggingface.co/Intel/musicgen-static-openvino">https://huggingface.co/Intel/musicgen-static-openvino</a> </p>
+<p>License: <a href="https://spdx.org/licenses/CC-BY-NC-4.0">cc-by-nc-4.0</a></p>
+)md";
+
+const char* music_restoration_apollo_mp3_jusperlee = R"md(
+<h1>Apollo MP3 Restore (@JusperLee)</h1>
+<p>An Apollo-based lossy restoration model that works well to restore quality of low-bitrate MP3s.</p>
+<p>See <a href="https://github.com/JusperLee">@JusperLee</a> project here: <a href="https://github.com/JusperLee/Apollo/">https://github.com/JusperLee/Apollo/</a></p>
+<p>As well as the HuggingFace project, here: <a href="https://huggingface.co/JusperLee/Apollo">https://huggingface.co/JusperLee/Apollo</a></p>
+<p>For use with <a href="https://github.com/intel/openvino-plugins-ai-audacity">OpenVINO AI Plugins for Audacity</a>, the pytorch models source models were converted to OpenVINO IR format, and stored here: TODO!</p>
+<p>License: <a href="https://huggingface.co/datasets/choosealicense/licenses/blob/main/markdown/cc-by-sa-4.0.md">cc-by-sa-4.0</a></p>
+)md";
+
+const char* music_restoration_apollo_universal_lew = R"md(
+<h1>Apollo Universal Restore (@Lew)</h1>
+<p>An Apollo-based lossy restoration model that works well for any lossy files.</p>
+<p>Trained by @Lew.</p>
+<p>The pre-trained model (by @Lew) &amp; config was originally uploaded via Discord, and eventually reposted by @deton24 here: <a href="https://github.com/deton24/Lew-s-vocal-enhancer-for-Apollo-by-JusperLee/releases/tag/uni">https://github.com/deton24/Lew-s-vocal-enhancer-for-Apollo-by-JusperLee/releases/tag/uni</a></p>
+<p>Unfortunately, since there is no 'official' HuggingFace source repo from @Lew with clear license available, we are unable to provide pre-converted OpenVINO models at this time.</p>
+<p>If you're brave, and want to try converting it yourself -- You can use guidance from <a href="https://github.com/RyanMetcalfeInt8/Music-Source-Separation-Training/tree/openvino_conversion/openvino_conversion#convert-apollo-models">here</a></p>
+<p>If you do convert it yourself, you should create a <code>apollo_universal</code> folder that contains <code>apollo_fwd.xml</code> &amp; <code>apollo_fwd.bin</code> (output of conversion steps), and place this folder in <code>openvino-models/music_restoration/</code>, and restart Audacity. After this, the model should show up as selectable from the drop-down list.</p>
+)md";
+
+const char* music_separation_demucs_v4 = R"md(
+<h1>Demucs-v4</h1>
+<p>Demucs-v4 is a state-of-the-art music source separation model that can separate drums, bass, vocals, and other stems from any song.</p>
+<p>Note that when the <code>(2 Stem) Vocals, Instrumentals</code> mode is selected, the instrumental track is produced by subtracting the vocals from the input track.
+<code>instrumental = input_track - vocal_stem</code></p>
+<p>For more info, take a look at the source project, here: <a href="https://github.com/facebookresearch/demucs">https://github.com/facebookresearch/demucs</a></p>
+<p>For use with <a href="https://github.com/intel/openvino-plugins-ai-audacity">OpenVINO AI Plugins for Audacity</a>, the pytorch models source models were converted to OpenVINO IR format, and stored here: <a href="https://huggingface.co/Intel/demucs-openvino">https://huggingface.co/Intel/demucs-openvino</a></p>
+<p>License: <a href="https://huggingface.co/datasets/choosealicense/licenses/blob/main/markdown/mit.md">MIT</a></p>
+)md";
+
+const char* music_separation_demucs_v4_6s = R"md(
+<h1>Demucs-v4 6s</h1>
+<p>A 6-stem variant of Demucs v4 that can separate an input track into drums, bass, vocals, guitar, piano, and 'other instruments' stems.</p>
+<p>For more info, take a look at the source project, here: <a href="https://github.com/facebookresearch/demucs">https://github.com/facebookresearch/demucs</a></p>
+<p><em>Note</em> that this model is considered to be <em>experimental</em>, and it is included here for completeness. To quote the <em>demucs</em> project README from <a href="https://github.com/facebookresearch/demucs?tab=readme-ov-file#demucs-music-source-separation">here</a>: "We are also releasing an experimental 6 sources model, that adds a <code>guitar</code> and <code>piano</code> source. Quick testing seems to show okay quality for <code>guitar</code>, but a lot of bleeding and artifacts for the <code>piano</code> source."</p>
+<p>For use with <a href="https://github.com/intel/openvino-plugins-ai-audacity">OpenVINO AI Plugins for Audacity</a>, the pytorch models source models were converted to OpenVINO IR format, and stored here: <a href="https://huggingface.co/Intel/demucs-openvino">https://huggingface.co/Intel/demucs-openvino</a></p>
+<p>License: <a href="https://huggingface.co/datasets/choosealicense/licenses/blob/main/markdown/mit.md">MIT</a></p>
+)md";
+
+const char* music_separation_demucs_v4_ft_bass = R"md(
+<h1>Demucs-v4 FT Drums</h1>
+<p>A FT (fine-tuned) variant of Demucs-v4 that gives slightly better results for bass, as compared with the native version of Demucs-v4.</p>
+<p>Note that this model natively produces a single 'bass' stem. The instrumental track, if selected, is produced by subtracting the bass stem from the input track:
+<code>instrumental = input_track - bass_stem</code></p>
+<p>For more info, take a look at the source project, here: <a href="https://github.com/facebookresearch/demucs">https://github.com/facebookresearch/demucs</a></p>
+<p>For use with <a href="https://github.com/intel/openvino-plugins-ai-audacity">OpenVINO AI Plugins for Audacity</a>, the pytorch models source models were converted to OpenVINO IR format, and stored here: <a href="https://huggingface.co/Intel/demucs-openvino">https://huggingface.co/Intel/demucs-openvino</a></p>
+<p>License: <a href="https://huggingface.co/datasets/choosealicense/licenses/blob/main/markdown/mit.md">MIT</a></p>
+)md";
+
+const char* music_separation_demucs_v4_ft_drums = R"md(
+<h1>Demucs-v4 FT Drums</h1>
+<p>A FT (fine-tuned) variant of Demucs-v4 that gives slightly better results for drums, as compared with the 'base' version of Demucs-v4.</p>
+<p>Note that this model natively produces a single drums stem. The instrumental track, if selected, is produced by subtracting the drum stem from the input track:
+<code>instrumental = input_track - drum_stem</code></p>
+<p>For more info, take a look at the source project, here: <a href="https://github.com/facebookresearch/demucs">https://github.com/facebookresearch/demucs</a></p>
+<p>For use with <a href="https://github.com/intel/openvino-plugins-ai-audacity">OpenVINO AI Plugins for Audacity</a>, the pytorch models source models were converted to OpenVINO IR format, and stored here: <a href="https://huggingface.co/Intel/demucs-openvino">https://huggingface.co/Intel/demucs-openvino</a></p>
+<p>License: <a href="https://huggingface.co/datasets/choosealicense/licenses/blob/main/markdown/mit.md">MIT</a></p>
+)md";
+
+const char* music_separation_demucs_v4_ft_other = R"md(
+<h1>Demucs-v4 FT Other Instruments</h1>
+<p>A FT (fine-tuned) variant of Demucs-v4 that gives slightly better results for 'other instruments', as compared with the native version of Demucs-v4.</p>
+<p>For Demucs-v4, 'Other Instruments' are classified as anything that is <em>not</em> drums, bass, or vocals.</p>
+<p>Note that this model natively produces a single 'other instruments' stem. The instrumental track, if selected, is produced by subtracting the 'other instruments' stem from the input track:
+<code>instrumental = input_track - other_instruments_stem</code></p>
+<p>For more info, take a look at the source project, here: <a href="https://github.com/facebookresearch/demucs">https://github.com/facebookresearch/demucs</a></p>
+<p>For use with <a href="https://github.com/intel/openvino-plugins-ai-audacity">OpenVINO AI Plugins for Audacity</a>, the pytorch models source models were converted to OpenVINO IR format, and stored here: <a href="https://huggingface.co/Intel/demucs-openvino">https://huggingface.co/Intel/demucs-openvino</a></p>
+<p>License: <a href="https://huggingface.co/datasets/choosealicense/licenses/blob/main/markdown/mit.md">MIT</a></p>
+)md";
+
+const char* music_separation_demucs_v4_ft_vocals = R"md(
+<h1>Demucs-v4 FT Vocals</h1>
+<p>A FT (fine-tuned) variant of Demucs-v4 that gives slightly better results for vocals, as compared with the 'base' version of Demucs-v4.</p>
+<p>Note that this model natively produces a single vocals stem. The instrumental track, if selected, is produced by subtracting the vocal stem from the input track:
+<code>instrumental = input_track - vocal_stem</code></p>
+<p>For more info, take a look at the source project, here: <a href="https://github.com/facebookresearch/demucs">https://github.com/facebookresearch/demucs</a></p>
+<p>For use with <a href="https://github.com/intel/openvino-plugins-ai-audacity">OpenVINO AI Plugins for Audacity</a>, the pytorch models source models were converted to OpenVINO IR format, and stored here: <a href="https://huggingface.co/Intel/demucs-openvino">https://huggingface.co/Intel/demucs-openvino</a></p>
+<p>License: <a href="https://huggingface.co/datasets/choosealicense/licenses/blob/main/markdown/mit.md">MIT</a></p>
+)md";
+
+const char* music_separation_mel_crowd_aufr33_viperx = R"md(
+<h1>MelBandRoformer Crowd Extraction / Removal (@aufr33 &amp; @viperx)</h1>
+<p>A MelBandRoformer-based crowd extraction / removal model that excels at extracting crowd noise from live recordings. As this is a MelBandRoformer model, it's quite a heavy model so expect long processing times.</p>
+<p>Note that this model natively produces a single 'crowd' stem. The 'no crowd' is produced by subtracting the 'crowd' stem from the input track:
+<code>no_crowd = input_track - crowd</code></p>
+<p>This model was trained by <a href="https://github.com/aufr33">@aufr33</a> &amp; <a href="https://github.com/playdasegunda">@viperx</a></p>
+<p>The source pytorch models (checkpoint) &amp; config were originally posted here: <a href="https://github.com/ZFTurbo/Music-Source-Separation-Training/releases/tag/v.1.0.4">https://github.com/ZFTurbo/Music-Source-Separation-Training/releases/tag/v.1.0.4</a></p>
+<p>For use with <a href="https://github.com/intel/openvino-plugins-ai-audacity">OpenVINO AI Plugins for Audacity</a>, the pytorch source models were converted to OpenVINO IR format, and stored here: TODO</p>
+<p>License: <a href="https://github.com/ZFTurbo/Music-Source-Separation-Training?tab=MIT-1-ov-file#readme">MIT</a></p>
+)md";
+
+const char* music_separation_mel_vocals_kimberley_jenson = R"md(
+<h1>MelBandRoformer Vocals (@KimberleyJensen)</h1>
+<p>A MelBandRoformer-based vocal extraction model that excels at extracting vocals from input tracks. It's a heavier model as compared with <em>Demucs-v4</em>, so expect longer processing times. It might be worth the wait though, as it can produce noticeably better results for certain tracks.</p>
+<p>Note that this model natively produces a single vocals stem. The instrumental track, if selected, is produced by subtracting the vocal stem from the input track:
+<code>instrumental = input_track - vocal_stem</code></p>
+<p>This model was trained by <a href="https://github.com/KimberleyJensen">@KimberleyJensen</a></p>
+<p>Take a look at the GitHub project, here: <a href="https://github.com/KimberleyJensen/Mel-Band-Roformer-Vocal-Model">https://github.com/KimberleyJensen/Mel-Band-Roformer-Vocal-Model</a></p>
+<p>Note that there is also a HuggingFace space here: <a href="https://huggingface.co/KimberleyJSN/melbandroformer">https://huggingface.co/KimberleyJSN/melbandroformer</a></p>
+<p>For use with <a href="https://github.com/intel/openvino-plugins-ai-audacity">OpenVINO AI Plugins for Audacity</a>, the pytorch source models were converted to OpenVINO IR format, and stored here: TODO</p>
+<p>License: <a href="https://huggingface.co/datasets/choosealicense/licenses/blob/main/markdown/gpl-3.0.md">GPL-3.0</a></p>
+)md";
+
+const char* music_separation_msdx23c_drum_sep_jarredou = R"md(
+<h1>MDX23C Drum Separation (@jarredou)</h1>
+<p>A MDX23C-based drum sepration model that can produce 5 stems: kick, snare, toms, hi-hat, cymbals</p>
+<p>As this is a MDX23C model, expect long processing times.</p>
+<p>Note that this model natively produces a five stems: kick, snare, toms, hi-hat, &amp; cymbals</p>
+<p>There is an additional 'residual' track that is produced, which contains the 'leftover' of whatever is not contained in these five native stems.</p>
+<p>It is produced using the following formula:
+<code>residual = input_track - (kick + snare + toms + hi-hat + cymbals)</code></p>
+<p>This model was trained by <a href="https://github.com/jarredou">@jarredou</a>.</p>
+<p>The original pytorch checkpoint / config were downloaded from their GitHub release here: <a href="https://github.com/jarredou/models/releases/tag/DrumSep">https://github.com/jarredou/models/releases/tag/DrumSep</a></p>
+<p>For use with <a href="https://github.com/intel/openvino-plugins-ai-audacity">OpenVINO AI Plugins for Audacity</a>, the pytorch source models were converted to OpenVINO IR format, and stored here: TODO</p>
+<p>License: <a href="https://github.com/jarredou/models?tab=License-1-ov-file#readme">Attribution-NonCommercial-NoDerivatives 4.0 International</a></p>
+)md";
+
+const char* noise_suppression_deepfilternet2 = R"md(
+<h1>DeepFilterNet2</h1>
+<p>A Noise Suppression model that operates on Full-Band Audio (48kHz) mono tracks. </p>
+<p>Note: You can process stereo tracks as well, and in this case the model will be run for the left &amp; right tracks, sequentially.</p>
+<p>This is a port of the DeepFilterNet2 features from this project: <a href="https://github.com/Rikorose/DeepFilterNet">https://github.com/Rikorose/DeepFilterNet</a></p>
+<p>For use with <a href="https://github.com/intel/openvino-plugins-ai-audacity">OpenVINO AI Plugins for Audacity</a>, the pytorch source models were converted to OpenVINO IR format, and posted here: <a href="https://huggingface.co/Intel/deepfilternet-openvino">https://huggingface.co/Intel/deepfilternet-openvino</a></p>
+<p>License: <a href="https://huggingface.co/datasets/choosealicense/licenses/blob/main/markdown/mit.md">MIT</a></p>
+)md";
+
+const char* noise_suppression_deepfilternet3 = R"md(
+<h1>DeepFilterNet3</h1>
+<p>A Noise Suppression model that operates on Full-Band Audio (48kHz) mono tracks.</p>
+<p>Note: You can process stereo tracks as well, and in this case the model will be run for the left &amp; right tracks, sequentially.</p>
+<p>This is a port of the DeepFilterNet3 features from this project: <a href="https://github.com/Rikorose/DeepFilterNet">https://github.com/Rikorose/DeepFilterNet</a></p>
+<p>For use with <a href="https://github.com/intel/openvino-plugins-ai-audacity">OpenVINO AI Plugins for Audacity</a>, the pytorch source models were converted to OpenVINO IR format, and posted here: <a href="https://huggingface.co/Intel/deepfilternet-openvino">https://huggingface.co/Intel/deepfilternet-openvino</a></p>
+<p>License: <a href="https://huggingface.co/datasets/choosealicense/licenses/blob/main/markdown/mit.md">MIT</a></p>
+)md";
+
+const char* noise_suppression_denseunet = R"md(
+<h1>DenseUNet</h1>
+<p>This is a model for noise suppression to make speech cleaner, and operates with 16khz mono audio tracks.</p>
+<p>For more information about this model, see <a href="https://docs.openvino.ai/2023.3/omz_models_model_noise_suppression_denseunet_ll_0001.html">here</a></p>
+<p>This model is stored in OpenVINO's Open Model Zoo repositories, here: <a href="https://storage.openvinotoolkit.org/repositories/open_model_zoo/2023.0/models_bin/1/noise-suppression-denseunet-ll-0001/">https://storage.openvinotoolkit.org/repositories/open_model_zoo/2023.0/models_bin/1/noise-suppression-denseunet-ll-0001/</a></p>
+)md";
+
+const char* reverb_removal_mel_band_dereverb_mono_anvuew = R"md(
+<h1>MelBandRoformer Dereverb Mono (@anvuew)</h1>
+<p>A MelBandRoformer-based model trained to extract / remove reverb from vocals. </p>
+<p>This particular (mono) variant seems to work well for spoken audio as well, even though it's primarily trained on vocal tracks (i.e. music). In the case of spoken audio tracks, you can try running directly on a mono or stereo track. </p>
+<p>We've noticed that for some spoken tracks with only <em>minor</em> reverb present, sometimes this model doesn't end up removing the reverb. This might seem odd, but in these cases you can try to <em>add</em> some additional reverb to the source track (<strong>Effects-&gt;Delay and Reverb-&gt;Reverb..</strong>), and then re-apply the <strong>Reverb Removal</strong> effect.</p>
+<p>As this is a MelBandRoformer model, so expect long processing times.</p>
+<p>This model was trained by <a href="https://huggingface.co/anvuew">@anvuew</a>.</p>
+<p>The original pytorch checkpoint / config were downloaded from HuggingFace here: <a href="https://huggingface.co/anvuew/dereverb_mel_band_roformer">https://huggingface.co/anvuew/dereverb_mel_band_roformer</a></p>
+<p>For use with <a href="https://github.com/intel/openvino-plugins-ai-audacity">OpenVINO AI Plugins for Audacity</a>, the pytorch source models were converted to OpenVINO IR format, and stored here: TODO</p>
+<p>License: <a href="https://huggingface.co/datasets/choosealicense/licenses/blob/main/markdown/gpl-3.0.md">GPL-3.0</a></p>
+)md";
+
+const char* super_resolution_basic_general = R"md(
+<h1>Basic (General) (FP16)</h1>
+<p>This super resolution model is intended to be used for enhancing all types of audio, including music and environmental sounds.</p>
+<p>To understand more about how to use the <em>Super Resolution</em>, you can read the documentation <a href="https://github.com/intel/openvino-plugins-ai-audacity/blob/main/doc/feature_doc/super_resolution/README.md">here</a></p>
+<p>You can also watch the YouTube video that desribes a bit more about how this feature works:<br />
+<a href="https://youtu.be/StrQef9lLMk?si=ba7V0SiRrbxjf5Of">Audio Super Resolution on your AI PC | AI with Guy | Intel Software</a></p>
+<p>Note that this effect is a port of this project: <a href="https://github.com/haoheliu/versatile_audio_super_resolution">https://github.com/haoheliu/versatile_audio_super_resolution</a></p>
+<p>For use with <a href="https://github.com/intel/openvino-plugins-ai-audacity">OpenVINO AI Plugins for Audacity</a>, the pytorch source models were converted to OpenVINO IR format, and stored here: <a href="https://huggingface.co/Intel/versatile_audio_super_resolution_openvino">https://huggingface.co/Intel/versatile_audio_super_resolution_openvino</a></p>
+<p>License: <a href="https://github.com/haoheliu/versatile_audio_super_resolution?tab=MIT-1-ov-file#readme">MIT</a></p>
+)md";
+
+const char* super_resolution_speech = R"md(
+<h1>Speech (FP16)</h1>
+<p>This super resolution model is intended to be used for enhancing audio with isolated speech.</p>
+<p>To understand more about how to use the <em>Super Resolution</em>, you can read the documentation <a href="https://github.com/intel/openvino-plugins-ai-audacity/blob/main/doc/feature_doc/super_resolution/README.md">here</a></p>
+<p>You can also watch the YouTube video that desribes a bit more about how this feature works:<br />
+<a href="https://youtu.be/StrQef9lLMk?si=ba7V0SiRrbxjf5Of">Audio Super Resolution on your AI PC | AI with Guy | Intel Software</a></p>
+<p>Note that this effect is a port of this project: <a href="https://github.com/haoheliu/versatile_audio_super_resolution">https://github.com/haoheliu/versatile_audio_super_resolution</a></p>
+<p>For use with <a href="https://github.com/intel/openvino-plugins-ai-audacity">OpenVINO AI Plugins for Audacity</a>, the pytorch source models were converted to OpenVINO IR format, and stored here: <a href="https://huggingface.co/Intel/versatile_audio_super_resolution_openvino">https://huggingface.co/Intel/versatile_audio_super_resolution_openvino</a></p>
+<p>License: <a href="https://github.com/haoheliu/versatile_audio_super_resolution?tab=MIT-1-ov-file#readme">MIT</a></p>
+)md";
+
+const char* whisper_transcription_info = R"md(
+<h2>Quantization Guide</h2>
+<p>The Whisper models available to use with this project come in three <em>quantization</em> variants: <em>FP16</em>, <em>INT8</em>, &amp; <em>INT4</em>.</p>
+<p><strong>FP16</strong>: Floating-Point 16 (i.e. half precision, 16-bit). Highest memory footprint &amp; utilization, but gives highest accuracy (transcription quality) in most cases. Lowest performance (on most systems).  </p>
+<p><strong>INT8</strong>: Integer-8 (8-bit) quantized. Roughly 1/2 of the memory footprint / utilization as compared with FP16. Improved performance on most systems, as compared with <em>FP16</em>. Minimal loss in accuracy (transcription quality) as compared with <em>FP16</em>.  </p>
+<p><strong>INT4</strong>: Integer-4 (4-bit) quantized. Roughly 1/4 of the memory footprint / utilization as compared with FP16. Improved performance on most systems, as compared with <em>INT8</em> &amp; <em>FP16</em>. Minimal loss in accuracy (transcription quality) as compared with <em>INT8</em> &amp; <em>FP16</em>.  </p>
+<h2>Model Variant Guide</h2>
+<p><strong>Note</strong>: The following guide has used / copied / modified some of the information found here: <a href="https://whisper-api.com/blog/models/">https://whisper-api.com/blog/models/</a></p>
+<p>There are many variants of whisper models, each one representing a tradeoff between accuracy, speed, and resource requirements.</p>
+<h3>Base:</h3>
+<p>A 74M parameter multilingual model.
+<strong>Multi-Language Support</strong>: Yes<br />
+<strong>Best for</strong>: General purpose transcription with reasonable accuracy when resources are limited. This is a great balance between speed and accuracy.  </p>
+<h3>Small:</h3>
+<p>A 244M parameter multilingual model.<br />
+<strong>Multi-Language Support</strong>: Yes<br />
+<strong>Best for</strong>: Daily transcription needs with good accuracy and reasonable speed. More accurate than base model but requires more resources.  </p>
+<h3>Medium:</h3>
+<p>A 769M parameter multilingual model.<br />
+<strong>Multi-Language Support</strong>: Yes<br />
+<strong>Best for</strong>: High-quality transcriptions where accuracy is important and you have decent computing resources.  </p>
+<h3>Large:</h3>
+<p>There are (currently) three variants of Whisper-large:<br />
+<strong>large-v1</strong>: Original large model (1.5B parameters)<br />
+<strong>large-v2</strong>: Improved large model<br />
+<strong>large-v3</strong>: Latest larger model with the best accuracy  (recommended). </p>
+<p><strong>Multi-Language Support</strong>: Yes<br />
+<strong>Best for</strong>: Professional transcription where maximum accuracy is essential, especially for <em>multi-language</em> transcriptions. </p>
+<h3>Distil-Large-V3:</h3>
+<p>A <em>distilled</em> (756M parameter) version of the <strong>large-v3</strong> model, which can produce <em>large-v3</em>-like quality but at a dramatically reduced memory &amp; processing cost. <strong>But</strong>.. it can only transcribe <em>english</em> recordings.  </p>
+<p><strong>Multi-Language Support</strong>: No (English-only transcription)<br />
+<strong>Best for</strong>: Professional <em>english</em> transcription where maximum accuracy is essential.  </p>
+<h2>How to use</h2>
+<p>There is some documentation <a href="https://github.com/intel/openvino-plugins-ai-audacity/tree/main/doc/feature_doc/whisper_transcription">here</a> about how to use these plugins.</p>
+<h2>OpenVINO Speech-to-Text collection</h2>
+<p>For use with <a href="https://github.com/intel/openvino-plugins-ai-audacity">OpenVINO AI Plugins for Audacity</a>, all of these models are downloaded from the OpenVINO's <a href="https://huggingface.co/collections/OpenVINO/speech-to-text-672321d5c070537a178a8aeb">Speech-to-Text</a> collection on HuggingFace.</p>
+<h2>License:</h2>
+<p>For <em>Distil</em> variants: <a href="https://github.com/huggingface/distil-whisper/blob/main/LICENSE">MIT</a>  </p>
+<p>For <em>Base</em>, <em>Small</em>, <em>Medium</em>, and <em>Large</em> variants: <a href="https://choosealicense.com/licenses/apache-2.0/">Apache-2.0</a>  </p>
+)md";
+

--- a/model_cards/gen_model_card_md_header.py
+++ b/model_cards/gen_model_card_md_header.py
@@ -1,0 +1,48 @@
+import os
+import argparse
+import markdown
+
+def sanitize_varname(path, root_dir):
+    """
+    Convert a relative file path to a safe C++ variable name.
+    Example: "vision/noise_reducer.md" -> "vision_noise_reducer"
+    """
+    rel_path = os.path.relpath(path, root_dir)
+    name = os.path.splitext(rel_path)[0]
+    name = name.replace(os.sep, '_').replace('-', '_').replace(' ', '_')
+    return ''.join(c if c.isalnum() or c == '_' else '_' for c in name)
+
+def make_raw_string(html, delim='md'):
+    return f'R"{delim}(\n{html}\n){delim}"'
+
+def find_md_files_recursively(root_dir):
+    for dirpath, _, filenames in os.walk(root_dir):
+        for f in filenames:
+            if f.lower().endswith('.md'):
+                yield os.path.join(dirpath, f)
+
+def generate_header(input_dir, output_file):
+    md_files = list(find_md_files_recursively(input_dir))
+
+    with open(output_file, 'w', encoding='utf-8') as out:
+        out.write("// Auto-generated header containing model card HTML strings\n")
+        out.write("#pragma once\n\n")
+
+        for md_path in md_files:
+            with open(md_path, 'r', encoding='utf-8') as md_file:
+                md_text = md_file.read()
+
+            html = markdown.markdown(md_text)
+            varname = sanitize_varname(md_path, input_dir)
+            raw_html = make_raw_string(html)
+            out.write(f'const char* {varname} = {raw_html};\n\n')
+
+    print(f"Header written to: {output_file} ({len(md_files)} model cards found)")
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Generate a C++ header from .md files recursively.")
+    parser.add_argument("input_dir", help="Top-level directory to search for .md files")
+    parser.add_argument("output_file", help="Output .h file")
+    args = parser.parse_args()
+
+    generate_header(args.input_dir, args.output_file)

--- a/model_cards/music_generation/music_gen_medium_mono_fp16.md
+++ b/model_cards/music_generation/music_gen_medium_mono_fp16.md
@@ -1,0 +1,9 @@
+# Music Gen Medium Mono (FP16)
+
+FP16 variant of facebook/musicgen-medium model. This is a mono model, therefore it will produce a mono track.
+
+Source Model: [facebook/musicgen-medium](https://huggingface.co/facebook/musicgen-medium)
+
+For use with [OpenVINO AI Plugins for Audacity](https://github.com/intel/openvino-plugins-ai-audacity), the pytorch models source models were converted to OpenVINO IR format, and stored here: [https://huggingface.co/Intel/musicgen-static-openvino](https://huggingface.co/Intel/musicgen-static-openvino) 
+
+License: [cc-by-nc-4.0](https://spdx.org/licenses/CC-BY-NC-4.0)

--- a/model_cards/music_generation/music_gen_medium_mono_int8.md
+++ b/model_cards/music_generation/music_gen_medium_mono_int8.md
@@ -1,0 +1,9 @@
+# Music Gen Medium Mono (INT8)
+
+INT8-quantized variant of facebook/musicgen-medium model. This is a mono model, therefore it will produce a mono track.
+
+Source Model: [facebook/musicgen-medium](https://huggingface.co/facebook/musicgen-medium)
+
+For use with [OpenVINO AI Plugins for Audacity](https://github.com/intel/openvino-plugins-ai-audacity), the pytorch models source models were converted to OpenVINO IR format, and stored here: [https://huggingface.co/Intel/musicgen-static-openvino](https://huggingface.co/Intel/musicgen-static-openvino) 
+
+License: [cc-by-nc-4.0](https://spdx.org/licenses/CC-BY-NC-4.0)

--- a/model_cards/music_generation/music_gen_small_mono_fp16.md
+++ b/model_cards/music_generation/music_gen_small_mono_fp16.md
@@ -1,0 +1,9 @@
+# Music Gen Small Mono (FP16)
+
+FP16 variant of facebook/musicgen-small model. This is a mono model, therefore it will produce a mono track.
+
+Source Model: [facebook/musicgen-small](https://huggingface.co/facebook/musicgen-small)
+
+For use with [OpenVINO AI Plugins for Audacity](https://github.com/intel/openvino-plugins-ai-audacity), the pytorch models source models were converted to OpenVINO IR format, and stored here: [https://huggingface.co/Intel/musicgen-static-openvino](https://huggingface.co/Intel/musicgen-static-openvino) 
+
+License: [cc-by-nc-4.0](https://spdx.org/licenses/CC-BY-NC-4.0)

--- a/model_cards/music_generation/music_gen_small_mono_int8.md
+++ b/model_cards/music_generation/music_gen_small_mono_int8.md
@@ -1,0 +1,9 @@
+# Music Gen Small Mono (INT8)
+
+INT8-quantized variant of facebook/musicgen-small model. This is a mono model, therefore it will produce a mono track.
+
+Source Model: [facebook/musicgen-small](https://huggingface.co/facebook/musicgen-small)
+
+For use with [OpenVINO AI Plugins for Audacity](https://github.com/intel/openvino-plugins-ai-audacity), the pytorch models source models were converted to OpenVINO IR format, and stored here: [https://huggingface.co/Intel/musicgen-static-openvino](https://huggingface.co/Intel/musicgen-static-openvino) 
+
+License: [cc-by-nc-4.0](https://spdx.org/licenses/CC-BY-NC-4.0)

--- a/model_cards/music_generation/music_gen_small_stereo_fp16.md
+++ b/model_cards/music_generation/music_gen_small_stereo_fp16.md
@@ -1,0 +1,9 @@
+# Music Gen Small Stereo (FP16)
+
+FP16 variant of facebook/musicgen-stereo-small model. This is a stereo model, therefore it will produce a stereo track.
+
+Source Model: [facebook/musicgen-stereo-small](https://huggingface.co/facebook/musicgen-stereo-small)
+
+For use with [OpenVINO AI Plugins for Audacity](https://github.com/intel/openvino-plugins-ai-audacity), the pytorch models source models were converted to OpenVINO IR format, and stored here: [https://huggingface.co/Intel/musicgen-static-openvino](https://huggingface.co/Intel/musicgen-static-openvino) 
+
+License: [cc-by-nc-4.0](https://spdx.org/licenses/CC-BY-NC-4.0)

--- a/model_cards/music_generation/music_gen_small_stereo_int8.md
+++ b/model_cards/music_generation/music_gen_small_stereo_int8.md
@@ -1,0 +1,9 @@
+# Music Gen Small Stereo (INT8)
+
+INT8-quantized variant of facebook/musicgen-stereo-small model. This is a stereo model, therefore it will produce a stereo track.
+
+Source Model: [facebook/musicgen-stereo-small](https://huggingface.co/facebook/musicgen-stereo-small)
+
+For use with [OpenVINO AI Plugins for Audacity](https://github.com/intel/openvino-plugins-ai-audacity), the pytorch models source models were converted to OpenVINO IR format, and stored here: [https://huggingface.co/Intel/musicgen-static-openvino](https://huggingface.co/Intel/musicgen-static-openvino) 
+
+License: [cc-by-nc-4.0](https://spdx.org/licenses/CC-BY-NC-4.0)

--- a/model_cards/music_restoration/apollo_mp3_jusperlee.md
+++ b/model_cards/music_restoration/apollo_mp3_jusperlee.md
@@ -1,0 +1,11 @@
+# Apollo MP3 Restore (@JusperLee)
+
+An Apollo-based lossy restoration model that works well to restore quality of low-bitrate MP3s.
+
+See [@JusperLee](https://github.com/JusperLee) project here: [https://github.com/JusperLee/Apollo/](https://github.com/JusperLee/Apollo/)
+
+As well as the HuggingFace project, here: [https://huggingface.co/JusperLee/Apollo](https://huggingface.co/JusperLee/Apollo)
+
+For use with [OpenVINO AI Plugins for Audacity](https://github.com/intel/openvino-plugins-ai-audacity), the pytorch models source models were converted to OpenVINO IR format, and stored here: TODO!
+
+License: [cc-by-sa-4.0](https://huggingface.co/datasets/choosealicense/licenses/blob/main/markdown/cc-by-sa-4.0.md)

--- a/model_cards/music_restoration/apollo_universal_lew.md
+++ b/model_cards/music_restoration/apollo_universal_lew.md
@@ -1,0 +1,13 @@
+# Apollo Universal Restore (@Lew)
+
+An Apollo-based lossy restoration model that works well for any lossy files.
+
+Trained by @Lew.
+
+The pre-trained model (by @Lew) & config was originally uploaded via Discord, and eventually reposted by @deton24 here: [https://github.com/deton24/Lew-s-vocal-enhancer-for-Apollo-by-JusperLee/releases/tag/uni](https://github.com/deton24/Lew-s-vocal-enhancer-for-Apollo-by-JusperLee/releases/tag/uni)
+
+Unfortunately, since there is no 'official' HuggingFace source repo from @Lew with clear license available, we are unable to provide pre-converted OpenVINO models at this time.
+
+If you're brave, and want to try converting it yourself -- You can use guidance from [here](https://github.com/RyanMetcalfeInt8/Music-Source-Separation-Training/tree/openvino_conversion/openvino_conversion#convert-apollo-models)
+
+If you do convert it yourself, you should create a `apollo_universal` folder that contains `apollo_fwd.xml` & `apollo_fwd.bin` (output of conversion steps), and place this folder in `openvino-models/music_restoration/`, and restart Audacity. After this, the model should show up as selectable from the drop-down list.

--- a/model_cards/music_separation/demucs_v4.md
+++ b/model_cards/music_separation/demucs_v4.md
@@ -1,0 +1,14 @@
+# Demucs-v4
+
+Demucs-v4 is a state-of-the-art music source separation model that can separate drums, bass, vocals, and other stems from any song.
+
+Note that when the `(2 Stem) Vocals, Instrumentals` mode is selected, the instrumental track is produced by subtracting the vocals from the input track.
+```
+instrumental = input_track - vocal_stem
+```
+
+For more info, take a look at the source project, here: [https://github.com/facebookresearch/demucs](https://github.com/facebookresearch/demucs)
+
+For use with [OpenVINO AI Plugins for Audacity](https://github.com/intel/openvino-plugins-ai-audacity), the pytorch models source models were converted to OpenVINO IR format, and stored here: [https://huggingface.co/Intel/demucs-openvino](https://huggingface.co/Intel/demucs-openvino)
+
+License: [MIT](https://huggingface.co/datasets/choosealicense/licenses/blob/main/markdown/mit.md)

--- a/model_cards/music_separation/demucs_v4_6s.md
+++ b/model_cards/music_separation/demucs_v4_6s.md
@@ -1,0 +1,11 @@
+# Demucs-v4 6s
+
+A 6-stem variant of Demucs v4 that can separate an input track into drums, bass, vocals, guitar, piano, and 'other instruments' stems.
+
+For more info, take a look at the source project, here: [https://github.com/facebookresearch/demucs](https://github.com/facebookresearch/demucs)
+
+*Note* that this model is considered to be *experimental*, and it is included here for completeness. To quote the *demucs* project README from [here](https://github.com/facebookresearch/demucs?tab=readme-ov-file#demucs-music-source-separation): "We are also releasing an experimental 6 sources model, that adds a `guitar` and `piano` source. Quick testing seems to show okay quality for `guitar`, but a lot of bleeding and artifacts for the `piano` source."
+
+For use with [OpenVINO AI Plugins for Audacity](https://github.com/intel/openvino-plugins-ai-audacity), the pytorch models source models were converted to OpenVINO IR format, and stored here: [https://huggingface.co/Intel/demucs-openvino](https://huggingface.co/Intel/demucs-openvino)
+
+License: [MIT](https://huggingface.co/datasets/choosealicense/licenses/blob/main/markdown/mit.md)

--- a/model_cards/music_separation/demucs_v4_ft_bass.md
+++ b/model_cards/music_separation/demucs_v4_ft_bass.md
@@ -1,0 +1,14 @@
+# Demucs-v4 FT Drums
+
+A FT (fine-tuned) variant of Demucs-v4 that gives slightly better results for bass, as compared with the native version of Demucs-v4.
+
+Note that this model natively produces a single 'bass' stem. The instrumental track, if selected, is produced by subtracting the bass stem from the input track:
+```
+instrumental = input_track - bass_stem
+```
+
+For more info, take a look at the source project, here: [https://github.com/facebookresearch/demucs](https://github.com/facebookresearch/demucs)
+
+For use with [OpenVINO AI Plugins for Audacity](https://github.com/intel/openvino-plugins-ai-audacity), the pytorch models source models were converted to OpenVINO IR format, and stored here: [https://huggingface.co/Intel/demucs-openvino](https://huggingface.co/Intel/demucs-openvino)
+
+License: [MIT](https://huggingface.co/datasets/choosealicense/licenses/blob/main/markdown/mit.md)

--- a/model_cards/music_separation/demucs_v4_ft_drums.md
+++ b/model_cards/music_separation/demucs_v4_ft_drums.md
@@ -1,0 +1,14 @@
+# Demucs-v4 FT Drums
+
+A FT (fine-tuned) variant of Demucs-v4 that gives slightly better results for drums, as compared with the 'base' version of Demucs-v4.
+
+Note that this model natively produces a single drums stem. The instrumental track, if selected, is produced by subtracting the drum stem from the input track:
+```
+instrumental = input_track - drum_stem
+```
+
+For more info, take a look at the source project, here: [https://github.com/facebookresearch/demucs](https://github.com/facebookresearch/demucs)
+
+For use with [OpenVINO AI Plugins for Audacity](https://github.com/intel/openvino-plugins-ai-audacity), the pytorch models source models were converted to OpenVINO IR format, and stored here: [https://huggingface.co/Intel/demucs-openvino](https://huggingface.co/Intel/demucs-openvino)
+
+License: [MIT](https://huggingface.co/datasets/choosealicense/licenses/blob/main/markdown/mit.md)

--- a/model_cards/music_separation/demucs_v4_ft_other.md
+++ b/model_cards/music_separation/demucs_v4_ft_other.md
@@ -1,0 +1,16 @@
+# Demucs-v4 FT Other Instruments
+
+A FT (fine-tuned) variant of Demucs-v4 that gives slightly better results for 'other instruments', as compared with the native version of Demucs-v4.
+
+For Demucs-v4, 'Other Instruments' are classified as anything that is *not* drums, bass, or vocals.
+
+Note that this model natively produces a single 'other instruments' stem. The instrumental track, if selected, is produced by subtracting the 'other instruments' stem from the input track:
+```
+instrumental = input_track - other_instruments_stem
+```
+
+For more info, take a look at the source project, here: [https://github.com/facebookresearch/demucs](https://github.com/facebookresearch/demucs)
+
+For use with [OpenVINO AI Plugins for Audacity](https://github.com/intel/openvino-plugins-ai-audacity), the pytorch models source models were converted to OpenVINO IR format, and stored here: [https://huggingface.co/Intel/demucs-openvino](https://huggingface.co/Intel/demucs-openvino)
+
+License: [MIT](https://huggingface.co/datasets/choosealicense/licenses/blob/main/markdown/mit.md)

--- a/model_cards/music_separation/demucs_v4_ft_vocals.md
+++ b/model_cards/music_separation/demucs_v4_ft_vocals.md
@@ -1,0 +1,14 @@
+# Demucs-v4 FT Vocals
+
+A FT (fine-tuned) variant of Demucs-v4 that gives slightly better results for vocals, as compared with the 'base' version of Demucs-v4.
+
+Note that this model natively produces a single vocals stem. The instrumental track, if selected, is produced by subtracting the vocal stem from the input track:
+```
+instrumental = input_track - vocal_stem
+```
+
+For more info, take a look at the source project, here: [https://github.com/facebookresearch/demucs](https://github.com/facebookresearch/demucs)
+
+For use with [OpenVINO AI Plugins for Audacity](https://github.com/intel/openvino-plugins-ai-audacity), the pytorch models source models were converted to OpenVINO IR format, and stored here: [https://huggingface.co/Intel/demucs-openvino](https://huggingface.co/Intel/demucs-openvino)
+
+License: [MIT](https://huggingface.co/datasets/choosealicense/licenses/blob/main/markdown/mit.md)

--- a/model_cards/music_separation/mel_crowd_aufr33_viperx.md
+++ b/model_cards/music_separation/mel_crowd_aufr33_viperx.md
@@ -1,0 +1,16 @@
+# MelBandRoformer Crowd Extraction / Removal (@aufr33 & @viperx)
+
+A MelBandRoformer-based crowd extraction / removal model that excels at extracting crowd noise from live recordings. As this is a MelBandRoformer model, it's quite a heavy model so expect long processing times.
+
+Note that this model natively produces a single 'crowd' stem. The 'no crowd' is produced by subtracting the 'crowd' stem from the input track:
+```
+no_crowd = input_track - crowd
+```
+
+This model was trained by [@aufr33](https://github.com/aufr33) & [@viperx](https://github.com/playdasegunda)
+
+The source pytorch models (checkpoint) & config were originally posted here: [https://github.com/ZFTurbo/Music-Source-Separation-Training/releases/tag/v.1.0.4](https://github.com/ZFTurbo/Music-Source-Separation-Training/releases/tag/v.1.0.4)
+
+For use with [OpenVINO AI Plugins for Audacity](https://github.com/intel/openvino-plugins-ai-audacity), the pytorch source models were converted to OpenVINO IR format, and stored here: TODO
+
+License: [MIT](https://github.com/ZFTurbo/Music-Source-Separation-Training?tab=MIT-1-ov-file#readme)

--- a/model_cards/music_separation/mel_vocals_kimberley_jenson.md
+++ b/model_cards/music_separation/mel_vocals_kimberley_jenson.md
@@ -1,0 +1,18 @@
+# MelBandRoformer Vocals (@KimberleyJensen)
+
+A MelBandRoformer-based vocal extraction model that excels at extracting vocals from input tracks. It's a heavier model as compared with *Demucs-v4*, so expect longer processing times. It might be worth the wait though, as it can produce noticeably better results for certain tracks.
+
+Note that this model natively produces a single vocals stem. The instrumental track, if selected, is produced by subtracting the vocal stem from the input track:
+```
+instrumental = input_track - vocal_stem
+```
+
+This model was trained by [@KimberleyJensen](https://github.com/KimberleyJensen)
+
+Take a look at the GitHub project, here: [https://github.com/KimberleyJensen/Mel-Band-Roformer-Vocal-Model](https://github.com/KimberleyJensen/Mel-Band-Roformer-Vocal-Model)
+
+Note that there is also a HuggingFace space here: [https://huggingface.co/KimberleyJSN/melbandroformer](https://huggingface.co/KimberleyJSN/melbandroformer)
+
+For use with [OpenVINO AI Plugins for Audacity](https://github.com/intel/openvino-plugins-ai-audacity), the pytorch source models were converted to OpenVINO IR format, and stored here: TODO
+
+License: [GPL-3.0](https://huggingface.co/datasets/choosealicense/licenses/blob/main/markdown/gpl-3.0.md)

--- a/model_cards/music_separation/msdx23c_drum_sep_jarredou.md
+++ b/model_cards/music_separation/msdx23c_drum_sep_jarredou.md
@@ -1,0 +1,22 @@
+# MDX23C Drum Separation (@jarredou)
+
+A MDX23C-based drum sepration model that can produce 5 stems: kick, snare, toms, hi-hat, cymbals
+
+As this is a MDX23C model, expect long processing times.
+
+Note that this model natively produces a five stems: kick, snare, toms, hi-hat, & cymbals
+
+There is an additional 'residual' track that is produced, which contains the 'leftover' of whatever is not contained in these five native stems.
+
+It is produced using the following formula:
+```
+residual = input_track - (kick + snare + toms + hi-hat + cymbals)
+```
+
+This model was trained by [@jarredou](https://github.com/jarredou).
+
+The original pytorch checkpoint / config were downloaded from their GitHub release here: [https://github.com/jarredou/models/releases/tag/DrumSep](https://github.com/jarredou/models/releases/tag/DrumSep)
+
+For use with [OpenVINO AI Plugins for Audacity](https://github.com/intel/openvino-plugins-ai-audacity), the pytorch source models were converted to OpenVINO IR format, and stored here: TODO
+
+License: [Attribution-NonCommercial-NoDerivatives 4.0 International](https://github.com/jarredou/models?tab=License-1-ov-file#readme)

--- a/model_cards/noise_suppression/deepfilternet2.md
+++ b/model_cards/noise_suppression/deepfilternet2.md
@@ -1,0 +1,11 @@
+# DeepFilterNet2
+
+A Noise Suppression model that operates on Full-Band Audio (48kHz) mono tracks. 
+
+Note: You can process stereo tracks as well, and in this case the model will be run for the left & right tracks, sequentially.
+
+This is a port of the DeepFilterNet2 features from this project: [https://github.com/Rikorose/DeepFilterNet](https://github.com/Rikorose/DeepFilterNet)
+
+For use with [OpenVINO AI Plugins for Audacity](https://github.com/intel/openvino-plugins-ai-audacity), the pytorch source models were converted to OpenVINO IR format, and posted here: [https://huggingface.co/Intel/deepfilternet-openvino](https://huggingface.co/Intel/deepfilternet-openvino)
+
+License: [MIT](https://huggingface.co/datasets/choosealicense/licenses/blob/main/markdown/mit.md)

--- a/model_cards/noise_suppression/deepfilternet3.md
+++ b/model_cards/noise_suppression/deepfilternet3.md
@@ -1,0 +1,11 @@
+# DeepFilterNet3
+
+A Noise Suppression model that operates on Full-Band Audio (48kHz) mono tracks.
+
+Note: You can process stereo tracks as well, and in this case the model will be run for the left & right tracks, sequentially.
+
+This is a port of the DeepFilterNet3 features from this project: [https://github.com/Rikorose/DeepFilterNet](https://github.com/Rikorose/DeepFilterNet)
+
+For use with [OpenVINO AI Plugins for Audacity](https://github.com/intel/openvino-plugins-ai-audacity), the pytorch source models were converted to OpenVINO IR format, and posted here: [https://huggingface.co/Intel/deepfilternet-openvino](https://huggingface.co/Intel/deepfilternet-openvino)
+
+License: [MIT](https://huggingface.co/datasets/choosealicense/licenses/blob/main/markdown/mit.md)

--- a/model_cards/noise_suppression/denseunet.md
+++ b/model_cards/noise_suppression/denseunet.md
@@ -1,0 +1,8 @@
+# DenseUNet
+
+This is a model for noise suppression to make speech cleaner, and operates with 16khz mono audio tracks.
+
+For more information about this model, see [here](https://docs.openvino.ai/2023.3/omz_models_model_noise_suppression_denseunet_ll_0001.html)
+
+This model is stored in OpenVINO's Open Model Zoo repositories, here: [https://storage.openvinotoolkit.org/repositories/open_model_zoo/2023.0/models_bin/1/noise-suppression-denseunet-ll-0001/](https://storage.openvinotoolkit.org/repositories/open_model_zoo/2023.0/models_bin/1/noise-suppression-denseunet-ll-0001/)
+

--- a/model_cards/reverb_removal/mel_band_dereverb_mono_anvuew.md
+++ b/model_cards/reverb_removal/mel_band_dereverb_mono_anvuew.md
@@ -1,0 +1,17 @@
+# MelBandRoformer Dereverb Mono (@anvuew)
+
+A MelBandRoformer-based model trained to extract / remove reverb from vocals. 
+
+This particular (mono) variant seems to work well for spoken audio as well, even though it's primarily trained on vocal tracks (i.e. music). In the case of spoken audio tracks, you can try running directly on a mono or stereo track. 
+
+We've noticed that for some spoken tracks with only *minor* reverb present, sometimes this model doesn't end up removing the reverb. This might seem odd, but in these cases you can try to *add* some additional reverb to the source track (**Effects->Delay and Reverb->Reverb..**), and then re-apply the **Reverb Removal** effect.
+
+As this is a MelBandRoformer model, so expect long processing times.
+
+This model was trained by [@anvuew](https://huggingface.co/anvuew).
+
+The original pytorch checkpoint / config were downloaded from HuggingFace here: [https://huggingface.co/anvuew/dereverb_mel_band_roformer](https://huggingface.co/anvuew/dereverb_mel_band_roformer)
+
+For use with [OpenVINO AI Plugins for Audacity](https://github.com/intel/openvino-plugins-ai-audacity), the pytorch source models were converted to OpenVINO IR format, and stored here: TODO
+
+License: [GPL-3.0](https://huggingface.co/datasets/choosealicense/licenses/blob/main/markdown/gpl-3.0.md)

--- a/model_cards/super_resolution/basic_general.md
+++ b/model_cards/super_resolution/basic_general.md
@@ -1,0 +1,14 @@
+# Basic (General) (FP16)
+
+This super resolution model is intended to be used for enhancing all types of audio, including music and environmental sounds.
+
+To understand more about how to use the *Super Resolution*, you can read the documentation [here](https://github.com/intel/openvino-plugins-ai-audacity/blob/main/doc/feature_doc/super_resolution/README.md)
+
+You can also watch the YouTube video that desribes a bit more about how this feature works:  
+[Audio Super Resolution on your AI PC | AI with Guy | Intel Software](https://youtu.be/StrQef9lLMk?si=ba7V0SiRrbxjf5Of)
+
+Note that this effect is a port of this project: [https://github.com/haoheliu/versatile_audio_super_resolution](https://github.com/haoheliu/versatile_audio_super_resolution)
+
+For use with [OpenVINO AI Plugins for Audacity](https://github.com/intel/openvino-plugins-ai-audacity), the pytorch source models were converted to OpenVINO IR format, and stored here: [https://huggingface.co/Intel/versatile_audio_super_resolution_openvino](https://huggingface.co/Intel/versatile_audio_super_resolution_openvino)
+
+License: [MIT](https://github.com/haoheliu/versatile_audio_super_resolution?tab=MIT-1-ov-file#readme)

--- a/model_cards/super_resolution/speech.md
+++ b/model_cards/super_resolution/speech.md
@@ -1,0 +1,14 @@
+# Speech (FP16)
+
+This super resolution model is intended to be used for enhancing audio with isolated speech.
+
+To understand more about how to use the *Super Resolution*, you can read the documentation [here](https://github.com/intel/openvino-plugins-ai-audacity/blob/main/doc/feature_doc/super_resolution/README.md)
+
+You can also watch the YouTube video that desribes a bit more about how this feature works:  
+[Audio Super Resolution on your AI PC | AI with Guy | Intel Software](https://youtu.be/StrQef9lLMk?si=ba7V0SiRrbxjf5Of)
+
+Note that this effect is a port of this project: [https://github.com/haoheliu/versatile_audio_super_resolution](https://github.com/haoheliu/versatile_audio_super_resolution)
+
+For use with [OpenVINO AI Plugins for Audacity](https://github.com/intel/openvino-plugins-ai-audacity), the pytorch source models were converted to OpenVINO IR format, and stored here: [https://huggingface.co/Intel/versatile_audio_super_resolution_openvino](https://huggingface.co/Intel/versatile_audio_super_resolution_openvino)
+
+License: [MIT](https://github.com/haoheliu/versatile_audio_super_resolution?tab=MIT-1-ov-file#readme)

--- a/model_cards/whisper_transcription/info.md
+++ b/model_cards/whisper_transcription/info.md
@@ -1,0 +1,58 @@
+## Quantization Guide
+
+The Whisper models available to use with this project come in three *quantization* variants: *FP16*, *INT8*, & *INT4*.
+
+**FP16**: Floating-Point 16 (i.e. half precision, 16-bit). Highest memory footprint & utilization, but gives highest accuracy (transcription quality) in most cases. Lowest performance (on most systems).  
+
+**INT8**: Integer-8 (8-bit) quantized. Roughly 1/2 of the memory footprint / utilization as compared with FP16. Improved performance on most systems, as compared with *FP16*. Minimal loss in accuracy (transcription quality) as compared with *FP16*.  
+
+**INT4**: Integer-4 (4-bit) quantized. Roughly 1/4 of the memory footprint / utilization as compared with FP16. Improved performance on most systems, as compared with *INT8* & *FP16*. Minimal loss in accuracy (transcription quality) as compared with *INT8* & *FP16*.  
+
+## Model Variant Guide 
+
+**Note**: The following guide has used / copied / modified some of the information found here: [https://whisper-api.com/blog/models/](https://whisper-api.com/blog/models/)
+
+There are many variants of whisper models, each one representing a tradeoff between accuracy, speed, and resource requirements.
+
+### Base:
+A 74M parameter multilingual model. 
+**Multi-Language Support**: Yes  
+**Best for**: General purpose transcription with reasonable accuracy when resources are limited. This is a great balance between speed and accuracy.  
+ 
+### Small:  
+A 244M parameter multilingual model.  
+**Multi-Language Support**: Yes  
+**Best for**: Daily transcription needs with good accuracy and reasonable speed. More accurate than base model but requires more resources.  
+  
+### Medium:  
+A 769M parameter multilingual model.  
+**Multi-Language Support**: Yes  
+**Best for**: High-quality transcriptions where accuracy is important and you have decent computing resources.  
+
+### Large:
+There are (currently) three variants of Whisper-large:  
+**large-v1**: Original large model (1.5B parameters)  
+**large-v2**: Improved large model  
+**large-v3**: Latest larger model with the best accuracy  (recommended). 
+
+**Multi-Language Support**: Yes  
+**Best for**: Professional transcription where maximum accuracy is essential, especially for *multi-language* transcriptions. 
+
+### Distil-Large-V3:  
+A *distilled* (756M parameter) version of the **large-v3** model, which can produce *large-v3*-like quality but at a dramatically reduced memory & processing cost. **But**.. it can only transcribe *english* recordings.  
+
+**Multi-Language Support**: No (English-only transcription)  
+**Best for**: Professional *english* transcription where maximum accuracy is essential.  
+ 
+## How to use
+There is some documentation [here](https://github.com/intel/openvino-plugins-ai-audacity/tree/main/doc/feature_doc/whisper_transcription) about how to use these plugins.
+
+## OpenVINO Speech-to-Text collection
+
+For use with [OpenVINO AI Plugins for Audacity](https://github.com/intel/openvino-plugins-ai-audacity), all of these models are downloaded from the OpenVINO's [Speech-to-Text](https://huggingface.co/collections/OpenVINO/speech-to-text-672321d5c070537a178a8aeb) collection on HuggingFace.
+
+## License:
+
+For *Distil* variants: [MIT](https://github.com/huggingface/distil-whisper/blob/main/LICENSE)  
+
+For *Base*, *Small*, *Medium*, and *Large* variants: [Apache-2.0](https://choosealicense.com/licenses/apache-2.0/)  


### PR DESCRIPTION
This PR introduces a few things.
1. The 'Info' button on Model Manager UI is now named 'Model Card'. Clicking it now pops up a nicer looking dxDialog with an HTML pane.
2. For each model supported in the project, there has been added a markdown .md file. There is a python utility function which will generate a header file of strings from these .md's. Since wxWidget can't display markdown natively, the utility script does a markdown-to-html conversion -- and this is the string stored in the header file.

Here is one such example of a model card for whisper:
<img width="2656" height="1925" alt="image" src="https://github.com/user-attachments/assets/a4d74c36-95db-488b-a2e1-635c00f67b75" />
