### PR TITLE
OpenVINO Plugin Preferences: Model Install Directory, Enable Cache, Cache Directory

### DIFF
--- a/mod-openvino/CMakeLists.txt
+++ b/mod-openvino/CMakeLists.txt
@@ -86,6 +86,8 @@ set( SOURCES
       OVWhisperTranscriptionGenAI.cpp
       OVWhisperTranscriptionGenAI.h
       OpenVINO.cpp
+      OpenVINOPluginPrefs.h
+      OpenVINOPluginPrefs.cpp
       OVStringUtils.h
       OVModelManagerUI.h
       OVModelManagerUI.cpp

--- a/mod-openvino/OVAudioSR.cpp
+++ b/mod-openvino/OVAudioSR.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 #include "OVAudioSR.h"
+#include "OpenVINOPluginPrefs.h"
 #include "WaveTrack.h"
 #include "WaveChannelUtilities.h"
 #include "EffectOutputTracks.h"
@@ -577,12 +578,6 @@ bool EffectOVAudioSR::Process(EffectInstance&, EffectSettings&)
 
    try
    {
-
-      FilePath cache_folder = FileNames::MkDir(wxFileName(FileNames::DataDir(), wxT("openvino-model-cache")).GetFullPath());
-
-      //Note: Using a variant of wstring conversion that seems to work more reliably when there are special characters present in the path.
-      std::string cache_path = wstring_to_string(wxFileName(cache_folder).GetFullPath().ToStdWstring());
-
       if (m_modelSelectionChoice < 0 || m_modelSelectionChoice >= mSupportedModels.size())
       {
          throw std::runtime_error("invalid m_modelSelectionChoice value");
@@ -612,6 +607,11 @@ bool EffectOVAudioSR::Process(EffectInstance&, EffectSettings&)
 
       auto model_folder = retrieved_model_info->installation_path;
 
+      std::string cache_path = "";
+      if (OpenVINOPluginSettings::ReadEnableCache()) {
+         auto cache_folder = FileNames::MkDir(wxFileName(OpenVINOPluginSettings::GetOrCreateCompiledModelCacheDir()).GetFullPath());
+         cache_path = wstring_to_string(wxFileName(cache_folder).GetFullPath().ToStdWstring());
+      }
       std::cout << "model_folder = " << model_folder << std::endl;
       std::cout << "cache_path = " << cache_path << std::endl;
 

--- a/mod-openvino/OVDemixerEffect.cpp
+++ b/mod-openvino/OVDemixerEffect.cpp
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 #include "OVDemixerEffect.h"
-
+#include "OpenVINOPluginPrefs.h"
 #include "WaveTrack.h"
 #include "EffectOutputTracks.h"
 #include "effects/EffectEditor.h"
@@ -380,10 +380,13 @@ bool EffectOVDemixerEffect::Process(EffectInstance&, EffectSettings&)
         std::shared_ptr< ov_demix::DemixModel > model;
         {
             auto device = mSupportedDevices[m_deviceSelectionChoice];
-            FilePath cache_folder = FileNames::MkDir(wxFileName(FileNames::DataDir(), wxT("openvino-model-cache")).GetFullPath());
 
-            //Note: Using a variant of wstring conversion that seems to work more reliably when there are special characters present in the path.
-            std::string cache_path = wstring_to_string(wxFileName(cache_folder).GetFullPath().ToStdWstring());
+            std::string cache_path = "";
+            if (OpenVINOPluginSettings::ReadEnableCache() && device != "CPU") {
+               // For non-CPU devices, use a cache folder to speed up loading times.
+               auto cache_folder = FileNames::MkDir(wxFileName(OpenVINOPluginSettings::GetOrCreateCompiledModelCacheDir()).GetFullPath());
+               cache_path = wstring_to_string(wxFileName(cache_folder).GetFullPath().ToStdWstring());
+            }
 
             std::cout << "model_folder = " << model_folder << std::endl;
             std::cout << "cache_path = " << cache_path << std::endl;

--- a/mod-openvino/OVModelManager.cpp
+++ b/mod-openvino/OVModelManager.cpp
@@ -1,4 +1,5 @@
 #include "OVModelManager.h"
+#include "OpenVINOPluginPrefs.h"
 #ifdef HAS_NETWORKING
 #include <NetworkManager.h>
 #include <Request.h>
@@ -25,33 +26,10 @@ std::shared_ptr<OVModelManager::ModelCollection> OVModelManager::GetModelCollect
    return it->second;
 }
 
-static inline std::optional<std::string> get_env_var(const std::string& name) {
-   if (const char* value = std::getenv(name.c_str())) {
-      return std::string(value); // copy into std::string
-   }
-   return std::nullopt; // not found
-}
-
 OVModelManager::OVModelManager()
 {
-   auto model_path_from_env = get_env_var("AUDACITY_OPENVINO_MODELS_PATH");
-
-   // Allow an environment variable to override the default path for installation.
-   if (model_path_from_env) {
-      FilePath env_openvino_models_path = FileNames::MkDir(wxFileName(wxString(*model_path_from_env)).GetFullPath());
-      mSearchPaths.push_back(env_openvino_models_path);
-   }
-
-   // Populate search paths where we look for installed models. Note that the first one appended to the list (appdata) is the *preferred*
-   // location to find models, and this is where models will be installed to with the UI-based ModelManager.
-   {
-      FilePath appdata_openvino_models_path = FileNames::MkDir(wxFileName(FileNames::DataDir(), wxT("openvino-models")).GetFullPath());
-      mSearchPaths.push_back(appdata_openvino_models_path);
-
-      //Add legacy search path so that we find models that were installed with older versions (from installer)
-      FilePath legacy_openvino_models_path = wxFileName(FileNames::BaseDir(), wxT("openvino-models")).GetFullPath();
-      mSearchPaths.push_back(legacy_openvino_models_path);
-   }
+   auto model_install_path = FileNames::MkDir(wxFileName(OpenVINOPluginSettings::GetOrCreateModelDir(true)).GetFullPath());
+   mSearchPaths.push_back(model_install_path);
 
    // initialize all of the details for all supported models.
    _populate_model_collection();

--- a/mod-openvino/OVModelManagerUI.cpp
+++ b/mod-openvino/OVModelManagerUI.cpp
@@ -1,4 +1,5 @@
 #include "OVModelManagerUI.h"
+#include "OpenVINOPluginPrefs.h"
 #include <thread>
 #include <wx/html/htmlwin.h>
 #include <wx/regex.h>
@@ -33,8 +34,8 @@ public:
    }
 };
 
-ModelEntryPanel::ModelEntryPanel(wxWindow* parent, const std::string peffect, std::shared_ptr<OVModelManager::ModelInfo> minfo, ModelManagerDialog* mgr)
-   : wxPanel(parent), effect(peffect), model(minfo), manager(mgr)
+ModelEntryPanel::ModelEntryPanel(wxWindow* parent, const std::string peffect, std::shared_ptr<OVModelManager::ModelInfo> minfo, ModelManagerDialog* mgr, bool restartReq)
+   : wxPanel(parent), effect(peffect), model(minfo), manager(mgr), restartRequired(restartReq)
 {
    SetMinSize(wxSize(550, 40));
 
@@ -48,7 +49,7 @@ ModelEntryPanel::ModelEntryPanel(wxWindow* parent, const std::string peffect, st
    sizer->Add(infoBtn, 0, wxALIGN_CENTER_VERTICAL);
 
    installButton = new wxButton(this, wxID_ANY, model->installed ? "Installed" : "Install");
-   installButton->Enable(!model->installed);
+   installButton->Enable(!model->installed && !restartRequired);
    if (model->baseUrl.empty()) {
       if (!model->installed) {
          installButton->SetLabelText("Not Installed");
@@ -59,6 +60,11 @@ ModelEntryPanel::ModelEntryPanel(wxWindow* parent, const std::string peffect, st
    // if we don't have networking support, disable (grey-out) install button.
    installButton->Enable(false);
 #endif
+
+   if (restartRequired && !model->installed) {
+      installButton->SetLabelText("Restart Required");
+      installButton->Enable(false);
+   }
 
    sizer->Add(installButton, 0, wxALIGN_CENTER_VERTICAL);
 
@@ -84,6 +90,12 @@ void ModelEntryPanel::OnInstall(wxCommandEvent&) {
 }
 
 void ModelEntryPanel::UpdateStatus() {
+   if (restartRequired && !model->installed) {
+      installButton->SetLabelText("Restart Required");
+      installButton->Enable(false);
+      return;
+   }
+
    installButton->SetLabelText(model->installed ? "Installed" : "Install");
    installButton->Enable(!model->installed);
 }
@@ -165,6 +177,8 @@ ModelManagerDialog::ModelManagerDialog(wxWindow* parent)
       OVModelManager::instance();
    }
 
+   const bool restartRequired = OpenVINOPluginSettings::IsModelDirRestartRequiredThisSession();
+
    SetMinSize(wxSize(600, 400));
    wxBoxSizer* mainSizer = new wxBoxSizer(wxVERTICAL);
 
@@ -173,6 +187,12 @@ ModelManagerDialog::ModelManagerDialog(wxWindow* parent)
    scrollPanel->SetMinSize(wxSize(550, 400));
    modelSizer = new wxBoxSizer(wxVERTICAL);
    scrollPanel->SetSizer(modelSizer);
+
+   if (restartRequired) {
+      auto* restartMsg = new wxStaticText(this, wxID_ANY,
+         "Please restart Audacity to install models (model directory changed).");
+      mainSizer->Add(restartMsg, 0, wxEXPAND | wxLEFT | wxRIGHT | wxTOP, 10);
+   }
 
    std::vector < std::string > allSections = {
       OVModelManager::MusicSepName(),
@@ -206,7 +226,7 @@ ModelManagerDialog::ModelManagerDialog(wxWindow* parent)
 
       for (auto& m : collection->models)
       {
-         auto* panel = new ModelEntryPanel(scrollPanel, s, m, this);
+         auto* panel = new ModelEntryPanel(scrollPanel, s, m, this, restartRequired);
          currentSectionInner->Add(panel, 0, wxEXPAND | wxALL, 2);
          allPanels.push_back(panel);
       }

--- a/mod-openvino/OVModelManagerUI.h
+++ b/mod-openvino/OVModelManagerUI.h
@@ -40,7 +40,7 @@ private:
 
 class ModelEntryPanel : public wxPanel {
 public:
-   ModelEntryPanel(wxWindow* parent, const std::string peffect, std::shared_ptr<OVModelManager::ModelInfo> minfo, ModelManagerDialog* manager);
+   ModelEntryPanel(wxWindow* parent, const std::string peffect, std::shared_ptr<OVModelManager::ModelInfo> minfo, ModelManagerDialog* manager, bool restartRequired);
 
    std::shared_ptr<OVModelManager::ModelInfo> GetModel() const { return model; }
    const std::string& GetEffect() const { return effect; }
@@ -57,6 +57,7 @@ private:
    std::string effect;
    std::shared_ptr<OVModelManager::ModelInfo> model;
    ModelManagerDialog* manager;
+   bool restartRequired{ false };
 
    wxButton* installButton;
 };

--- a/mod-openvino/OVNoiseSuppression.cpp
+++ b/mod-openvino/OVNoiseSuppression.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 #include "OVNoiseSuppression.h"
+#include "OpenVINOPluginPrefs.h"
 #include "WaveTrack.h"
 #include "EffectOutputTracks.h"
 #include "effects/EffectEditor.h"
@@ -369,8 +370,13 @@ bool EffectOVNoiseSuppression::Process(EffectInstance&, EffectSettings&)
          std::shared_ptr< NoiseSuppressionModel > ret;
          try
          {
-            FilePath cache_folder = FileNames::MkDir(wxFileName(FileNames::DataDir(), wxT("openvino-model-cache")).GetFullPath());
-            std::string cache_path = wstring_to_string(wxFileName(cache_folder).GetFullPath().ToStdWstring());
+            auto device = mSupportedDevices[m_deviceSelectionChoice];
+            std::string cache_path = "";
+            if (OpenVINOPluginSettings::ReadEnableCache() && device != "CPU") {
+               // For non-CPU devices, use a cache folder to speed up loading times.
+               auto cache_folder = FileNames::MkDir(wxFileName(OpenVINOPluginSettings::GetOrCreateCompiledModelCacheDir()).GetFullPath());
+               cache_path = wstring_to_string(wxFileName(cache_folder).GetFullPath().ToStdWstring());
+            }
 
             // WA for OpenVINO locale caching issue (https://github.com/openvinotoolkit/openvino/issues/24370)
             OVLocaleWorkaround wa;
@@ -413,7 +419,7 @@ bool EffectOVNoiseSuppression::Process(EffectInstance&, EffectSettings&)
                }
 
                auto ns_df = std::make_shared< NoiseSuppressionDFModel >(audacity::ToUTF8(wxFileName(model_folder).GetFullPath()),
-                  mSupportedDevices[m_deviceSelectionChoice], cache_path, dfnet_selection);
+                  device, cache_path, dfnet_selection);
 
                std::cout << "setting attn limit of " << mAttenuationLimit << std::endl;
                ns_df->SetAttenLimit(mAttenuationLimit);

--- a/mod-openvino/OVWhisperTranscriptionGenAI.cpp
+++ b/mod-openvino/OVWhisperTranscriptionGenAI.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 #include "OVWhisperTranscriptionGenAI.h"
+#include "OpenVINOPluginPrefs.h"
 #include "LoadEffects.h"
 #include "WaveTrack.h"
 #include "EffectOutputTracks.h"
@@ -515,15 +516,12 @@ bool EffectOVWhisperTranscriptionGenAI::Whisper(std::vector<float>& mono_samples
    auto whisper_model_path = retrieved_model_info->installation_path;
    std::cout << "whisper_model_path = " << whisper_model_path << std::endl;
 
-   FilePath cache_folder = FileNames::MkDir(wxFileName(FileNames::DataDir(), wxT("openvino-model-cache")).GetFullPath());
-
-   //Note: Using a variant of wstring conversion that seems to work more reliably when there are special characters present in the path.
-   std::string cache_path = wstring_to_string(wxFileName(cache_folder).GetFullPath().ToStdWstring());
-
    std::shared_ptr< ov::genai::WhisperPipeline > pipeline;
 
    ov::AnyMap properties;
-   if (device_name != "CPU") {
+   if (OpenVINOPluginSettings::ReadEnableCache() && device_name != "CPU") {
+      auto cache_folder = FileNames::MkDir(wxFileName(OpenVINOPluginSettings::GetOrCreateCompiledModelCacheDir()).GetFullPath());
+      auto cache_path = wstring_to_string(wxFileName(cache_folder).GetFullPath().ToStdWstring());
       std::cout << "Setting cache_dir to " << cache_path << std::endl;
       properties = { ov::cache_dir(cache_path) };
    }

--- a/mod-openvino/OpenVINOPluginPrefs.cpp
+++ b/mod-openvino/OpenVINOPluginPrefs.cpp
@@ -1,0 +1,328 @@
+// OpenVINOPluginSettings.cpp
+// One-stop implementation: prefs helpers + Preferences UI page + registration.
+
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4996) // avoid /WX breaks from Audacity deprecation warnings in headers
+#endif
+
+#include "PrefsPanel.h"
+#include "ShuttleGui.h"
+#include "Prefs.h"
+#include "FileNames.h"
+#include "MemoryX.h"
+#include "Internat.h"
+
+#include <wx/filename.h>
+#include <wx/textctrl.h>
+#include <wx/button.h>
+#include <wx/checkbox.h>
+#include <wx/dirdlg.h>
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
+
+#include "OpenVINOPluginPrefs.h"
+#include "OVModelManagerUI.h"
+#include "AudacityMessageBox.h"
+
+namespace OpenVINOPluginSettings
+{
+   // Preference keys (stored in audacity.cfg)
+   inline constexpr const wchar_t* kPrefModelDir = L"/OpenVINOPlugins/ModelDir";
+   inline constexpr const wchar_t* kPrefEnableCache = L"/OpenVINOPlugins/EnableModelCache";
+   inline constexpr const wchar_t* kPrefCompiledCache = L"/OpenVINOPlugins/CompiledModelCacheDir";
+
+
+   static inline std::optional<std::string> get_env_var(const std::string& name) {
+      if (const char* value = std::getenv(name.c_str())) {
+         return std::string(value); // copy into std::string
+      }
+      return std::nullopt; // not found
+   }
+
+   static wxString DefaultModelsDirPath()
+   {
+      // if AUDACITY_OPENVINO_MODELS_PATH env is set, return that path.
+      auto model_path_from_env = get_env_var("AUDACITY_OPENVINO_MODELS_PATH");
+      if (model_path_from_env) {
+         return wxFileName(wxString(*model_path_from_env)).GetFullPath();
+      }
+
+      // Otherwise, return the default path under Audacity's data directory.
+      return wxFileName(FileNames::DataDir(), wxT("openvino-models")).GetFullPath();
+   }
+
+   static wxString DefaultCacheDirPath()
+   {
+      return wxFileName(FileNames::DataDir(), wxT("openvino-model-cache")).GetFullPath();
+   }
+
+   static wxString EnsureDirPref(const wchar_t* prefKey,
+      const wxString& defaultPath,
+      bool persistIfMissing)
+   {
+      wxString value = gPrefs->Read(prefKey, wxString{});
+      if (value.empty())
+         value = defaultPath;
+
+      value = FileNames::MkDir(value);
+
+      if (persistIfMissing) {
+         const wxString current = gPrefs->Read(prefKey, wxString{});
+         if (current.empty() || current != value)
+            gPrefs->Write(prefKey, value);
+      }
+
+      return value;
+   }
+
+   wxString GetOrCreateModelDir(bool persistIfMissing)
+   {
+      return EnsureDirPref(kPrefModelDir, DefaultModelsDirPath(), persistIfMissing);
+   }
+
+   wxString GetOrCreateCompiledModelCacheDir(bool persistIfMissing)
+   {
+      return EnsureDirPref(kPrefCompiledCache, DefaultCacheDirPath(), persistIfMissing);
+   }
+
+   bool ReadEnableCache(bool defaultValue)
+   {
+      return gPrefs->ReadBool(kPrefEnableCache, defaultValue);
+   }
+
+} // namespace OpenVINOPluginSettings
+
+// -----------------------------
+// Preferences UI page
+// -----------------------------
+namespace {
+
+   enum
+   {
+      kModelDirTextID = 5000,
+      kModelDirBrowseID,
+
+      kOpenModelManagerButtonID,
+
+      kEnableCacheCheckID,
+      kCacheDirTextID,
+      kCacheDirBrowseID,
+   };
+
+   class OpenVINOPluginsPrefs final : public PrefsPanel
+   {
+   public:
+      OpenVINOPluginsPrefs(wxWindow* parent, wxWindowID winid, AudacityProject* project)
+         : PrefsPanel(parent, winid, XO("OpenVINO Plugins"))
+      {
+         Populate();
+      }
+
+      ComponentInterfaceSymbol GetSymbol() const override
+      {
+         return ComponentInterfaceSymbol{ wxT("OpenVINOPluginsPrefs") };
+      }
+
+      TranslatableString GetDescription() const override
+      {
+         return XO("Preferences for OpenVINO-based AI plugins");
+      }
+
+      void Populate()
+      {
+         // Ensure defaults exist so other code can just Read() them later
+         (void)OpenVINOPluginSettings::GetOrCreateModelDir(true);
+         (void)OpenVINOPluginSettings::GetOrCreateCompiledModelCacheDir(true);
+
+         // If the pref was never set before, set it to true (and persist it)
+         if (!gPrefs->HasEntry(OpenVINOPluginSettings::kPrefEnableCache)) {
+            gPrefs->Write(OpenVINOPluginSettings::kPrefEnableCache, true);
+         }
+         // Snapshot the value that was active when the prefs page opened.
+         // (Read raw, but fall back to the resolved default to avoid empty comparisons.)
+         mOriginalModelDir = gPrefs->Read(OpenVINOPluginSettings::kPrefModelDir, wxString{});
+         if (mOriginalModelDir.empty())
+            mOriginalModelDir = OpenVINOPluginSettings::GetOrCreateModelDir(/*persistIfMissing=*/true);
+
+
+         ShuttleGui S(this, eIsCreatingFromPrefs);
+         PopulateOrExchange(S);
+
+         UpdateCacheControls();
+      }
+
+      void PopulateOrExchange(ShuttleGui& S) override
+      {
+         S.SetBorder(2);
+         S.StartScroller();
+
+         S.StartStatic(XO("Models"));
+         {
+            S.StartMultiColumn(3, wxEXPAND);
+            {
+               S.SetStretchyCol(1);
+
+               S.Id(kModelDirTextID);
+               mModelDirText = S.TieTextBox(
+                  XO("Model Install Directory:"),
+                  { OpenVINOPluginSettings::kPrefModelDir,
+                    OpenVINOPluginSettings::GetOrCreateModelDir(true) },
+                  30
+               );
+               S.Id(kModelDirBrowseID).AddButton(XO("Browse..."));
+
+               S.Id(kOpenModelManagerButtonID).AddButton(XO("Open Model Manager"));
+               S.AddSpace(2);
+            }
+            S.EndMultiColumn();
+         }
+         S.EndStatic();
+
+         S.StartStatic(XO("Caching"));
+         {
+            S.StartMultiColumn(3, wxEXPAND);
+            {
+               S.SetStretchyCol(1);
+
+               S.Id(kEnableCacheCheckID);
+               mEnableCacheCheck = S.TieCheckBox(
+                  XO("Enable Compiled Model Caching"),
+                  OpenVINOPluginSettings::kPrefEnableCache
+               );
+
+               S.AddSpace(1);
+               S.AddSpace(1);
+
+               S.Id(kCacheDirTextID);
+               mCacheDirText = S.TieTextBox(
+                  XO("Compiled Model Cache Directory:"),
+                  { OpenVINOPluginSettings::kPrefCompiledCache,
+                    OpenVINOPluginSettings::GetOrCreateCompiledModelCacheDir(true) },
+                  30
+               );
+               S.Id(kCacheDirBrowseID).AddButton(XO("Browse..."));
+            }
+            S.EndMultiColumn();
+         }
+         S.EndStatic();
+
+         S.EndScroller();
+      }
+
+      bool Commit() override
+      {
+         ShuttleGui S(this, eIsSavingToPrefs);
+         PopulateOrExchange(S);
+
+         // Read back the saved value
+         wxString newModelDir = gPrefs->Read(OpenVINOPluginSettings::kPrefModelDir, wxString{});
+
+         // Normalize a bit to reduce false positives
+         // (Windows paths in wxString are usually case-insensitive; also trim whitespace)
+         auto normalize = [](wxString s) {
+            s.Trim(true).Trim(false);
+#if defined(__WXMSW__)
+            s.MakeLower();
+#endif
+            // Strip trailing separators (optional)
+            while (s.EndsWith(wxFILE_SEP_PATH))
+               s.RemoveLast();
+            return s;
+            };
+
+         if (!mOriginalModelDir.empty() && !newModelDir.empty() &&
+            normalize(mOriginalModelDir) != normalize(newModelDir))
+         {
+            AudacityMessageBox(
+               XO("The installed model directory has been updated. Please close & re-open Audacity!"),
+               XO("Restart Required"),
+               wxOK | wxCENTRE | wxICON_INFORMATION
+            );
+
+            // Update snapshot so repeated Apply clicks don't re-pop the dialog
+            mOriginalModelDir = newModelDir;
+         }
+
+
+         return true;
+      }
+
+   private:
+      void UpdateCacheControls()
+      {
+         const bool enabled = mEnableCacheCheck && mEnableCacheCheck->GetValue();
+
+         if (mCacheDirText)
+            mCacheDirText->Enable(enabled);
+
+         if (auto* btn = wxDynamicCast(FindWindow(kCacheDirBrowseID), wxButton))
+            btn->Enable(enabled);
+      }
+
+      void OnToggleCache(wxCommandEvent&)
+      {
+         UpdateCacheControls();
+      }
+
+      static void BrowseIntoTextCtrl(wxWindow* parent,
+         wxTextCtrl* tc,
+         const TranslatableString& title)
+      {
+         if (!tc)
+            return;
+
+         wxDirDialogWrapper dlog(parent, title, tc->GetValue());
+         if (dlog.ShowModal() == wxID_CANCEL)
+            return;
+
+         const wxString path = dlog.GetPath();
+         if (!path.empty())
+            tc->SetValue(path);
+      }
+
+      void OnBrowseModelDir(wxCommandEvent&)
+      {
+         BrowseIntoTextCtrl(this, mModelDirText, XO("Choose a model directory"));
+      }
+
+      void OnBrowseCacheDir(wxCommandEvent&)
+      {
+         BrowseIntoTextCtrl(this, mCacheDirText, XO("Choose a compiled model cache directory"));
+      }
+
+      void OnOpenModelManager(wxCommandEvent&)
+      {
+         ShowModelManagerDialog();
+      }
+
+   private:
+      wxTextCtrl* mModelDirText{ nullptr };
+      wxCheckBox* mEnableCacheCheck{ nullptr };
+      wxTextCtrl* mCacheDirText{ nullptr };
+
+      wxString mOriginalModelDir;
+
+      wxDECLARE_EVENT_TABLE();
+   };
+
+   wxBEGIN_EVENT_TABLE(OpenVINOPluginsPrefs, PrefsPanel)
+      EVT_BUTTON(kModelDirBrowseID, OpenVINOPluginsPrefs::OnBrowseModelDir)
+      EVT_BUTTON(kOpenModelManagerButtonID, OpenVINOPluginsPrefs::OnOpenModelManager)
+      EVT_BUTTON(kCacheDirBrowseID, OpenVINOPluginsPrefs::OnBrowseCacheDir)
+      EVT_CHECKBOX(kEnableCacheCheckID, OpenVINOPluginsPrefs::OnToggleCache)
+      wxEND_EVENT_TABLE()
+
+      // Registration: static initializer invoked when your module DLL is loaded.
+      PrefsPanel::Registration sAttachment{
+         wxT("OpenVINO Plugins"),
+         [](wxWindow* parent, wxWindowID winid, AudacityProject* project) -> PrefsPanel* {
+            wxASSERT(parent);
+            return safenew OpenVINOPluginsPrefs(parent, winid, project);
+         },
+         true
+   };
+
+} // anonymous namespace

--- a/mod-openvino/OpenVINOPluginPrefs.cpp
+++ b/mod-openvino/OpenVINOPluginPrefs.cpp
@@ -18,6 +18,7 @@
 #include <wx/button.h>
 #include <wx/checkbox.h>
 #include <wx/dirdlg.h>
+#include <wx/log.h>
 
 #ifdef _MSC_VER
 #pragma warning(pop)
@@ -67,7 +68,13 @@ namespace OpenVINOPluginSettings
       if (value.empty())
          value = defaultPath;
 
+      const wxString requestedPath = value;
       value = FileNames::MkDir(value);
+
+      if (value.empty() || !wxFileName::DirExists(value)) {
+         wxLogWarning("OpenVINO preferences: unable to ensure directory exists for key '%s'. Requested='%s', Result='%s'",
+            wxString(prefKey), requestedPath, value);
+      }
 
       if (persistIfMissing) {
          const wxString current = gPrefs->Read(prefKey, wxString{});
@@ -119,6 +126,20 @@ namespace {
          : PrefsPanel(parent, winid, XO("OpenVINO Plugins"))
       {
          Populate();
+
+         mHostDialog = wxGetTopLevelParent(this);
+         if (mHostDialog) {
+            mHostDialog->Bind(wxEVT_BUTTON, &OpenVINOPluginsPrefs::OnDialogConfirm, this, wxID_OK);
+            mHostDialog->Bind(wxEVT_BUTTON, &OpenVINOPluginsPrefs::OnDialogConfirm, this, wxID_APPLY);
+         }
+      }
+
+      ~OpenVINOPluginsPrefs() override
+      {
+         if (mHostDialog) {
+            mHostDialog->Unbind(wxEVT_BUTTON, &OpenVINOPluginsPrefs::OnDialogConfirm, this, wxID_OK);
+            mHostDialog->Unbind(wxEVT_BUTTON, &OpenVINOPluginsPrefs::OnDialogConfirm, this, wxID_APPLY);
+         }
       }
 
       ComponentInterfaceSymbol GetSymbol() const override
@@ -214,6 +235,9 @@ namespace {
 
       bool Commit() override
       {
+         if (!ValidatePendingDirectories(/*reportErrors=*/true))
+            return false;
+
          ShuttleGui S(this, eIsSavingToPrefs);
          PopulateOrExchange(S);
 
@@ -251,6 +275,66 @@ namespace {
       }
 
    private:
+      bool ValidatePendingDirectories(bool reportErrors)
+      {
+         const wxString pendingModelDir = mModelDirText ? mModelDirText->GetValue() : wxString{};
+         const wxString pendingCacheDir = mCacheDirText ? mCacheDirText->GetValue() : wxString{};
+         const bool pendingEnableCache = mEnableCacheCheck ? mEnableCacheCheck->GetValue() : true;
+
+         auto validateDirOrReport = [this, reportErrors](const wchar_t* prefKey,
+            const wxString& path,
+            const TranslatableString& label,
+            wxTextCtrl* controlToFocus) -> bool
+            {
+               if (IsDirectoryWritable(path))
+                  return true;
+
+               if (reportErrors) {
+                  wxLogWarning("OpenVINO preferences: selected path for key '%s' is not writable: '%s'",
+                     wxString(prefKey), path);
+
+                  AudacityMessageBox(
+                     XO("The selected %s is not writable (or cannot be created). Please choose a writable directory.")
+                     .Format(label),
+                     XO("Invalid Directory"),
+                     wxOK | wxCENTRE | wxICON_WARNING
+                  );
+
+                  if (controlToFocus)
+                     controlToFocus->SetFocus();
+               }
+
+               return false;
+            };
+
+         if (!validateDirOrReport(OpenVINOPluginSettings::kPrefModelDir,
+            pendingModelDir,
+            XO("model install directory"),
+            mModelDirText))
+            return false;
+
+         if (pendingEnableCache &&
+            !validateDirOrReport(OpenVINOPluginSettings::kPrefCompiledCache,
+               pendingCacheDir,
+               XO("compiled model cache directory"),
+               mCacheDirText))
+            return false;
+
+         return true;
+      }
+
+      static bool IsDirectoryWritable(wxString path)
+      {
+         path.Trim(true).Trim(false);
+         if (path.empty())
+            return false;
+
+         const wxString ensuredPath = FileNames::MkDir(path);
+         return !ensuredPath.empty() &&
+            wxFileName::DirExists(ensuredPath) &&
+            wxFileName::IsDirWritable(ensuredPath);
+      }
+
       void UpdateCacheControls()
       {
          const bool enabled = mEnableCacheCheck && mEnableCacheCheck->GetValue();
@@ -298,10 +382,19 @@ namespace {
          ShowModelManagerDialog();
       }
 
+      void OnDialogConfirm(wxCommandEvent& event)
+      {
+         if (!ValidatePendingDirectories(/*reportErrors=*/true))
+            return;
+
+         event.Skip();
+      }
+
    private:
       wxTextCtrl* mModelDirText{ nullptr };
       wxCheckBox* mEnableCacheCheck{ nullptr };
       wxTextCtrl* mCacheDirText{ nullptr };
+      wxWindow* mHostDialog{ nullptr };
 
       wxString mOriginalModelDir;
 

--- a/mod-openvino/OpenVINOPluginPrefs.cpp
+++ b/mod-openvino/OpenVINOPluginPrefs.cpp
@@ -34,6 +34,7 @@ namespace OpenVINOPluginSettings
    inline constexpr const wchar_t* kPrefModelDir = L"/OpenVINOPlugins/ModelDir";
    inline constexpr const wchar_t* kPrefEnableCache = L"/OpenVINOPlugins/EnableModelCache";
    inline constexpr const wchar_t* kPrefCompiledCache = L"/OpenVINOPlugins/CompiledModelCacheDir";
+   static bool gModelDirRestartRequiredThisSession = false;
 
 
    static inline std::optional<std::string> get_env_var(const std::string& name) {
@@ -85,6 +86,7 @@ namespace OpenVINOPluginSettings
       return value;
    }
 
+
    wxString GetOrCreateModelDir(bool persistIfMissing)
    {
       return EnsureDirPref(kPrefModelDir, DefaultModelsDirPath(), persistIfMissing);
@@ -98,6 +100,16 @@ namespace OpenVINOPluginSettings
    bool ReadEnableCache(bool defaultValue)
    {
       return gPrefs->ReadBool(kPrefEnableCache, defaultValue);
+   }
+
+   bool IsModelDirRestartRequiredThisSession()
+   {
+      return gModelDirRestartRequiredThisSession;
+   }
+
+   void MarkModelDirRestartRequiredThisSession()
+   {
+      gModelDirRestartRequiredThisSession = true;
    }
 
 } // namespace OpenVINOPluginSettings
@@ -260,6 +272,7 @@ namespace {
          if (!mOriginalModelDir.empty() && !newModelDir.empty() &&
             normalize(mOriginalModelDir) != normalize(newModelDir))
          {
+            OpenVINOPluginSettings::MarkModelDirRestartRequiredThisSession();
             AudacityMessageBox(
                XO("The installed model directory has been updated. Please close & re-open Audacity!"),
                XO("Restart Required"),

--- a/mod-openvino/OpenVINOPluginPrefs.h
+++ b/mod-openvino/OpenVINOPluginPrefs.h
@@ -13,4 +13,8 @@ namespace OpenVINOPluginSettings
 
    // Read/write helpers
    bool ReadEnableCache(bool defaultValue = true);
+
+   // Session-only flag: true when model install directory changed and restart is required.
+   bool IsModelDirRestartRequiredThisSession();
+   void MarkModelDirRestartRequiredThisSession();
 }

--- a/mod-openvino/OpenVINOPluginPrefs.h
+++ b/mod-openvino/OpenVINOPluginPrefs.h
@@ -1,0 +1,16 @@
+// OpenVINOPluginSettings.h
+#pragma once
+
+#include <wx/string.h>
+
+namespace OpenVINOPluginSettings
+{
+   // Returns a directory that exists; if unset, defaults to DataDir()/openvino-models and creates it.
+   wxString GetOrCreateModelDir(bool persistIfMissing = true);
+
+   // Returns a directory that exists; if unset, defaults to DataDir()/openvino-model-cache and creates it.
+   wxString GetOrCreateCompiledModelCacheDir(bool persistIfMissing = true);
+
+   // Read/write helpers
+   bool ReadEnableCache(bool defaultValue = true);
+}

--- a/mod-openvino/noise_suppression/deepfilternet/dfnet_model.cpp
+++ b/mod-openvino/noise_suppression/deepfilternet/dfnet_model.cpp
@@ -117,7 +117,7 @@ namespace ov_deepfilternet
 
       _core = std::make_shared< ov::Core >();
 
-      if (openvino_cache_dir)
+      if (openvino_cache_dir && !openvino_cache_dir->empty())
       {
          _core->set_property(ov::cache_dir(*openvino_cache_dir));
       }

--- a/mod-openvino/noise_suppression/noise_suppression_omz_model.cpp
+++ b/mod-openvino/noise_suppression/noise_suppression_omz_model.cpp
@@ -136,7 +136,9 @@ void NoiseSuppressionOMZModel::_compile_noise_suppression_model(std::string mode
 {
    _core = std::make_shared< ov::Core >();
 
-   _core->set_property(ov::cache_dir(cache_dir));
+   if (!cache_dir.empty()) {
+      _core->set_property(ov::cache_dir(cache_dir));
+   }
 
    std::shared_ptr<ov::Model> model = _core->read_model(model_path);
 


### PR DESCRIPTION
It's been a common ask from users to have the ability to have more control over model installation & cache folders. Until now, it has always been some fixed location.

This PR adds a section to Audacity preferences menu, specific to OpenVINO Plugins:
<img width="1281" height="727" alt="image" src="https://github.com/user-attachments/assets/0c90e8a0-4b80-44f7-bec3-c34effa06f7a" />

From here, users can modify the default model installation & cache folders (as well as enable / disable caching altogether).