### PR TITLE
Model Manager: Show details of installation errors via UI

### DIFF
--- a/mod-openvino/OVModelManager.cpp
+++ b/mod-openvino/OVModelManager.cpp
@@ -309,7 +309,7 @@ static OVModelManager::InstallResult download_model_files(const std::string& eff
 
       // write to file here
       response->setOnDataReceivedCallback(
-         [response, wx_file, &bError, &bytes_downloaded_so_far, callback, &total_download_size, &file_error_summary, &file_error_details, &effect, model_info, &url, fullFilePath](audacity::network_manager::IResponse*)
+         [response, wx_file, &bError, &bytes_downloaded_so_far, callback, &total_download_size, &file_error_summary, &file_error_details, &effect, model_info, url, fullFilePath](audacity::network_manager::IResponse*)
          {
             // only attempt save if request succeeded
             int httpCode = response->getHTTPCode();

--- a/mod-openvino/OVModelManager.cpp
+++ b/mod-openvino/OVModelManager.cpp
@@ -5,13 +5,13 @@
 #include <Request.h>
 #include <IResponse.h>
 #endif
-#include <iostream>
 #include <thread>
 #include <chrono>
 #include <sstream>
 #include <future>
 
 #include <wx/file.h>
+#include <wx/log.h>
 
 namespace {
 
@@ -127,16 +127,10 @@ static void _check_installed_model_impl(std::shared_ptr<OVModelManager::ModelInf
       wxFileName fullFilePath(search_path_base + "/" + model_info->relative_path + "/" + file);
       fullFilePath.Normalize();
 
-      std::cout << "fullFilePath = " << fullFilePath.GetFullPath().ToStdString() << std::endl;
       if (!fullFilePath.FileExists())
       {
          all_found = false;
-         std::cout << "    file doesn't exist." << std::endl;
          break;
-      }
-      else
-      {
-         std::cout << "    file exists." << std::endl;
       }
    }
 
@@ -151,7 +145,6 @@ static void _check_installed_model_impl(std::shared_ptr<OVModelManager::ModelInf
 
       model_info->installed = true;
       model_info->installation_path = fullInstallationPath.ToStdString();
-      std::cout << "Set installation path to " << model_info->installation_path << std::endl;
    }
 }
 
@@ -191,7 +184,7 @@ OVModelManager::InstallResult OVModelManager::install_model_size(std::shared_ptr
    total_size = 0;
 #ifdef HAS_NETWORKING
    if (!model_info) {
-      std::cout << "install_model_size called on null model_info" << std::endl;
+   wxLogError("OVModelManager::install_model_size called on null model_info.");
       return InstallResult::Failure(
          "Model size calculation failed.",
          BuildInstallDetails({}, {}, "Size Check", "install_model_size received a null model pointer."));
@@ -208,8 +201,7 @@ OVModelManager::InstallResult OVModelManager::install_model_size(std::shared_ptr
          request = audacity::network_manager::Request(url);
       }
       catch (const std::exception& error) {
-         std::cout << "Error creating request from url=" << url << std::endl;
-         std::cout << "Exceptiond details: " << error.what() << std::endl;
+         wxLogError("OVModelManager: failed to create HEAD request for URL '%s'. Exception: %s", url, error.what());
          return InstallResult::Failure(
             "Could not create a download request.",
             BuildInstallDetails({}, model_info->model_name, "Size Check", "Could not create a HEAD request for model download size lookup.", url, error.what()));
@@ -224,21 +216,11 @@ OVModelManager::InstallResult OVModelManager::install_model_size(std::shared_ptr
          }
 
          if ((response->getHTTPCode() != 200) && (response->getHTTPCode() != 302)) {
-            std::cout << "error fetching head for URL = " << url << std::endl;
+            wxLogError("OVModelManager: unexpected HTTP status %d while fetching HEAD for URL '%s'.", response->getHTTPCode(), url);
             return InstallResult::Failure(
                "Could not retrieve model download metadata.",
                BuildInstallDetails({}, model_info->model_name, "Size Check", "HEAD request returned an unexpected HTTP status.", url, "HTTP status: " + std::to_string(response->getHTTPCode())));
          }
-
-#if 0
-         std::cout << "file = " << file << std::endl;
-         auto headers_list = response->getHeaders();
-         for (auto& header : headers_list)
-         {
-            std::cout << "    header name: " << header.Name << std::endl;
-            std::cout << "    header value: " << header.Value << std::endl;
-         }
-#endif
 
          // For LFS files on GitHub (usually large ones, like .bin's) have 'X-Linked-Size' headers,
          // so we look for those first. If that doesn't exist, we use 'Content-Length' header.
@@ -249,8 +231,6 @@ OVModelManager::InstallResult OVModelManager::install_model_size(std::shared_ptr
             if (response->hasHeader(header)) {
                std::string length = response->getHeader(header);
                size_t size = (size_t)std::stoull(length);
-
-               std::cout << "file: " << file << ", size = " << size << std::endl;
                total_size += size;
 
                size_header_found = true;
@@ -259,15 +239,14 @@ OVModelManager::InstallResult OVModelManager::install_model_size(std::shared_ptr
 
          if (!size_header_found)
          {
-            std::cout << "response does not have 'X-Linked-Size' or 'Content-Length' headers for URL=" << url << std::endl;
+            wxLogError("OVModelManager: response missing X-Linked-Size and Content-Length headers for URL '%s'.", url);
             return InstallResult::Failure(
                "Could not determine model download size.",
                BuildInstallDetails({}, model_info->model_name, "Size Check", "Response did not include X-Linked-Size or Content-Length.", url));
          }
       }
       catch (const std::exception& error) {
-         std::cout << "Error getting file head details (for size calculation) for url=" << url << std::endl;
-         std::cout << "Exception details: " << error.what() << std::endl;
+         wxLogError("OVModelManager: exception while reading HEAD response for URL '%s'. Exception: %s", url, error.what());
          return InstallResult::Failure(
             "Could not retrieve model download metadata.",
             BuildInstallDetails({}, model_info->model_name, "Size Check", "Exception while reading HEAD response for size calculation.", url, error.what()));
@@ -317,10 +296,9 @@ static OVModelManager::InstallResult download_model_files(const std::string& eff
       wxFileName fullFilePath(base_openvino_models_path + "/" + model_info->relative_path + "/" + file);
       fullFilePath.Normalize();
 
-      std::cout << "Saving to " << fullFilePath.GetFullPath().ToStdString() << std::endl;
-
       std::shared_ptr<wxFile> wx_file = std::make_shared<wxFile>(fullFilePath.GetFullPath(), wxFile::write);
       if (!wx_file->IsOpened()) {
+         wxLogError("OVModelManager: failed to open destination file for writing: '%s'.", fullFilePath.GetFullPath());
          return OVModelManager::InstallResult::Failure(
             "Could not open the destination file for writing.",
             BuildInstallDetails(effect, model_info->model_name, "Download", "Failed to open the destination file before writing downloaded data.", fullFilePath.GetFullPath().ToStdString()));
@@ -343,7 +321,7 @@ static OVModelManager::InstallResult download_model_files(const std::string& eff
                if (wx_file->Error()) {
                   int last_error = wx_file->GetLastError();
 
-                  std::cout << "uh oh... ex_file Error! last_error=" << last_error << std::endl;
+                  wxLogError("OVModelManager: file write error (wxFile last_error=%d) for '%s'.", last_error, fullFilePath.GetFullPath());
                   file_error_summary = "Writing downloaded model data failed.";
                   file_error_details = BuildInstallDetails(
                      effect,
@@ -366,7 +344,10 @@ static OVModelManager::InstallResult download_model_files(const std::string& eff
 
                if (bytesWritten != responseData.size())
                {
-                  std::cout << "uh oh... bytesWritten != responseData.size() " << std::endl;
+                  wxLogError("OVModelManager: incomplete file write for '%s' (written=%llu, received=%llu).",
+                     fullFilePath.GetFullPath(),
+                     static_cast<unsigned long long>(bytesWritten),
+                     static_cast<unsigned long long>(responseData.size()));
                   file_error_summary = "Incomplete model file write detected.";
                   file_error_details = BuildInstallDetails(
                      effect,
@@ -382,7 +363,7 @@ static OVModelManager::InstallResult download_model_files(const std::string& eff
             }
             else
             {
-               std::cout << "uh oh... httpCode = " << httpCode << std::endl;
+               wxLogError("OVModelManager: GET request returned unexpected HTTP status %d for URL '%s'.", httpCode, url);
                file_error_summary = "Model download returned an unexpected HTTP status.";
                file_error_details = BuildInstallDetails(
                   effect,
@@ -414,8 +395,6 @@ static OVModelManager::InstallResult download_model_files(const std::string& eff
       if (bError) {
          return OVModelManager::InstallResult::Failure(file_error_summary, file_error_details);
       }
-
-      std::cout << "finished downloading " << url << std::endl;
    }
 
    return OVModelManager::InstallResult::Success();
@@ -431,7 +410,7 @@ OVModelManager::InstallResult OVModelManager::install_model(std::string effect, 
    try {
       auto it = mModelCollection.find(effect);
       if (it == mModelCollection.end()) {
-         std::cout << "Model Collection for effect=" << effect << " not found." << std::endl;
+         wxLogError("OVModelManager: model collection for effect '%s' not found.", effect);
          return InstallResult::Failure(
             "Model install failed before download started.",
             BuildInstallDetails(effect, model_id, "Lookup", "No model collection was found for the requested effect."));
@@ -448,7 +427,7 @@ OVModelManager::InstallResult OVModelManager::install_model(std::string effect, 
       }
 
       if (!bFound) {
-         std::cout << "Model Info for model_id=" << model_id << " not found." << std::endl;
+         wxLogError("OVModelManager: model info for model_id '%s' not found.", model_id);
          return InstallResult::Failure(
             "Model install failed before download started.",
             BuildInstallDetails(effect, model_id, "Lookup", "No model info entry was found for the requested model."));
@@ -458,7 +437,7 @@ OVModelManager::InstallResult OVModelManager::install_model(std::string effect, 
       auto sizeResult = install_model_size(model_info, total_download_size);
       if (!sizeResult)
       {
-         std::cout << "install_model_size failed." << std::endl;
+         wxLogError("OVModelManager: install_model_size failed for model '%s'.", model_id);
          return WrapInstallFailure(
             effect,
             model_id,
@@ -487,7 +466,7 @@ OVModelManager::InstallResult OVModelManager::install_model(std::string effect, 
             auto dependencySizeResult = install_model_size(d, dependencies_size);
             if (!dependencySizeResult)
             {
-               std::cout << "install_model_size failed for dependencies: " << d->model_name << std::endl;
+               wxLogError("OVModelManager: install_model_size failed for dependency '%s'.", d->model_name);
                return WrapInstallFailure(
                   effect,
                   model_id,
@@ -502,8 +481,6 @@ OVModelManager::InstallResult OVModelManager::install_model(std::string effect, 
       }
 
       size_t bytes_downloaded_so_far = 0;
-
-      std::cout << "Total size we are about to download = " << total_download_size << std::endl;
 
       if (!model_info->dependencies.empty()) {
          for (auto& d : model_info->dependencies) {
@@ -525,10 +502,6 @@ OVModelManager::InstallResult OVModelManager::install_model(std::string effect, 
                      "A required dependency did not verify after download.",
                      BuildInstallDetails(effect, model_id, "Dependency Verification", "Downloaded dependency files were not found during post-download verification.", d->model_name));
                }
-            }
-            else
-            {
-               std::cout << "dependency: " << d->model_name << " is already installed." << std::endl;
             }
          }
       }
@@ -556,8 +529,7 @@ OVModelManager::InstallResult OVModelManager::install_model(std::string effect, 
          BuildInstallDetails(effect, model_id, "Verification", "Download completed, but the expected installed files were not found in the target directory.", base_openvino_models_path.ToStdString()));
    }
    catch (const std::exception& error) {
-      std::cout << "install_model: exception caught for model_id = " << model_id << std::endl;
-      std::cout << "exception details: " << error.what() << std::endl;
+      wxLogError("OVModelManager: exception while installing model '%s'. Exception: %s", model_id, error.what());
       return InstallResult::Failure(
          "Unexpected exception while installing the model.",
          BuildInstallDetails(effect, model_id, "Exception", "install_model caught an unexpected exception.", {}, error.what()));

--- a/mod-openvino/OVModelManager.cpp
+++ b/mod-openvino/OVModelManager.cpp
@@ -13,6 +13,60 @@
 
 #include <wx/file.h>
 
+namespace {
+
+std::string BuildInstallDetails(
+   const std::string& effect,
+   const std::string& modelName,
+   const std::string& stage,
+   const std::string& message,
+   const std::string& resource = {},
+   const std::string& extra = {})
+{
+   std::ostringstream stream;
+   stream << "Effect: " << effect << "\n";
+   stream << "Model: " << modelName << "\n";
+   stream << "Stage: " << stage << "\n";
+   stream << "Message: " << message;
+
+   if (!resource.empty()) {
+      stream << "\nResource: " << resource;
+   }
+
+   if (!extra.empty()) {
+      stream << "\nDetails: " << extra;
+   }
+
+   return stream.str();
+}
+
+OVModelManager::InstallResult WrapInstallFailure(
+   const std::string& effect,
+   const std::string& requestedModel,
+   const std::string& stage,
+   const std::string& message,
+   const OVModelManager::InstallResult& cause,
+   const std::string& resource = {})
+{
+   std::ostringstream extra;
+   if (!cause.summary.empty()) {
+      extra << "Cause Summary: " << cause.summary;
+   }
+
+   if (!cause.details.empty()) {
+      if (extra.tellp() > 0) {
+         extra << "\n\n";
+      }
+      extra << cause.details;
+   }
+
+   return OVModelManager::InstallResult::Failure(
+      message,
+      BuildInstallDetails(effect, requestedModel, stage, message, resource, extra.str()));
+}
+
+}
+
 
 std::shared_ptr<OVModelManager::ModelCollection> OVModelManager::GetModelCollection(const std::string& effect)
 {
@@ -132,14 +186,17 @@ static inline void mkdir_relative_paths(std::string relative_file, wxString base
    }
 }
 
-size_t OVModelManager::install_model_size(std::shared_ptr<ModelInfo> model_info)
+OVModelManager::InstallResult OVModelManager::install_model_size(std::shared_ptr<ModelInfo> model_info, size_t& total_size)
 {
+   total_size = 0;
 #ifdef HAS_NETWORKING
    if (!model_info) {
       std::cout << "install_model_size called on null model_info" << std::endl;
+      return InstallResult::Failure(
+         "Model size calculation failed.",
+         BuildInstallDetails({}, {}, "Size Check", "install_model_size received a null model pointer."));
    }
 
-   size_t total_size = 0;
    auto baseUrl = model_info->baseUrl;
    audacity::network_manager::NetworkManager& manager = audacity::network_manager::NetworkManager::GetInstance();
 
@@ -153,7 +210,9 @@ size_t OVModelManager::install_model_size(std::shared_ptr<ModelInfo> model_info)
       catch (const std::exception& error) {
          std::cout << "Error creating request from url=" << url << std::endl;
          std::cout << "Exceptiond details: " << error.what() << std::endl;
-         return 0;
+         return InstallResult::Failure(
+            "Could not create a download request.",
+            BuildInstallDetails({}, model_info->model_name, "Size Check", "Could not create a HEAD request for model download size lookup.", url, error.what()));
       }
 
       try {
@@ -166,7 +225,9 @@ size_t OVModelManager::install_model_size(std::shared_ptr<ModelInfo> model_info)
 
          if ((response->getHTTPCode() != 200) && (response->getHTTPCode() != 302)) {
             std::cout << "error fetching head for URL = " << url << std::endl;
-            return 0;
+            return InstallResult::Failure(
+               "Could not retrieve model download metadata.",
+               BuildInstallDetails({}, model_info->model_name, "Size Check", "HEAD request returned an unexpected HTTP status.", url, "HTTP status: " + std::to_string(response->getHTTPCode())));
          }
 
 #if 0
@@ -199,26 +260,38 @@ size_t OVModelManager::install_model_size(std::shared_ptr<ModelInfo> model_info)
          if (!size_header_found)
          {
             std::cout << "response does not have 'X-Linked-Size' or 'Content-Length' headers for URL=" << url << std::endl;
-            return 0;
+            return InstallResult::Failure(
+               "Could not determine model download size.",
+               BuildInstallDetails({}, model_info->model_name, "Size Check", "Response did not include X-Linked-Size or Content-Length.", url));
          }
       }
       catch (const std::exception& error) {
          std::cout << "Error getting file head details (for size calculation) for url=" << url << std::endl;
          std::cout << "Exception details: " << error.what() << std::endl;
-         return 0;
+         return InstallResult::Failure(
+            "Could not retrieve model download metadata.",
+            BuildInstallDetails({}, model_info->model_name, "Size Check", "Exception while reading HEAD response for size calculation.", url, error.what()));
       }
    }
 
-   return total_size;
+   return InstallResult::Success();
 #else
-   throw std::runtime_error("install_model_size called, but this build has no networking support!");
+   return InstallResult::Failure(
+      "Model downloads are not available in this build.",
+      BuildInstallDetails({}, model_info ? model_info->model_name : std::string{}, "Size Check", "install_model_size called, but this build has no networking support."));
 #endif
 }
 
-static void download_model_files(std::shared_ptr<OVModelManager::ModelInfo> model_info, const FilePath &base_openvino_models_path, size_t total_download_size,
+static OVModelManager::InstallResult download_model_files(const std::string& effect, std::shared_ptr<OVModelManager::ModelInfo> model_info, const FilePath &base_openvino_models_path, size_t total_download_size,
    size_t& bytes_downloaded_so_far, OVModelManager::ProgressCallback callback)
 {
 #ifdef HAS_NETWORKING
+   if (!model_info) {
+      return OVModelManager::InstallResult::Failure(
+         "Model download failed.",
+         BuildInstallDetails(effect, {}, "Download", "download_model_files received a null model pointer."));
+   }
+
    audacity::network_manager::NetworkManager& manager = audacity::network_manager::NetworkManager::GetInstance();
 
    bool bError = false;
@@ -227,8 +300,18 @@ static void download_model_files(std::shared_ptr<OVModelManager::ModelInfo> mode
    auto postUrl = model_info->postUrl;
    for (auto& file : model_info->fileList) {
       std::string url = baseUrl + file + postUrl;
-      audacity::network_manager::Request request(url);
-      auto response = manager.doGet(request);
+
+      audacity::network_manager::Request request;
+      std::shared_ptr<audacity::network_manager::IResponse> response;
+      try {
+         request = audacity::network_manager::Request(url);
+         response = manager.doGet(request);
+      }
+      catch (const std::exception& error) {
+         return OVModelManager::InstallResult::Failure(
+            "Model download request failed.",
+            BuildInstallDetails(effect, model_info->model_name, "Download", "Could not start a GET request for the model file.", url, error.what()));
+      }
 
       mkdir_relative_paths(model_info->relative_path + "/" + file, base_openvino_models_path);
       wxFileName fullFilePath(base_openvino_models_path + "/" + model_info->relative_path + "/" + file);
@@ -237,10 +320,18 @@ static void download_model_files(std::shared_ptr<OVModelManager::ModelInfo> mode
       std::cout << "Saving to " << fullFilePath.GetFullPath().ToStdString() << std::endl;
 
       std::shared_ptr<wxFile> wx_file = std::make_shared<wxFile>(fullFilePath.GetFullPath(), wxFile::write);
+      if (!wx_file->IsOpened()) {
+         return OVModelManager::InstallResult::Failure(
+            "Could not open the destination file for writing.",
+            BuildInstallDetails(effect, model_info->model_name, "Download", "Failed to open the destination file before writing downloaded data.", fullFilePath.GetFullPath().ToStdString()));
+      }
+
+      std::string file_error_summary;
+      std::string file_error_details;
 
       // write to file here
       response->setOnDataReceivedCallback(
-         [response, wx_file, &bError, &bytes_downloaded_so_far, callback, &total_download_size](audacity::network_manager::IResponse*)
+         [response, wx_file, &bError, &bytes_downloaded_so_far, callback, &total_download_size, &file_error_summary, &file_error_details, &effect, model_info, &url, fullFilePath](audacity::network_manager::IResponse*)
          {
             // only attempt save if request succeeded
             int httpCode = response->getHTTPCode();
@@ -253,6 +344,14 @@ static void download_model_files(std::shared_ptr<OVModelManager::ModelInfo> mode
                   int last_error = wx_file->GetLastError();
 
                   std::cout << "uh oh... ex_file Error! last_error=" << last_error << std::endl;
+                  file_error_summary = "Writing downloaded model data failed.";
+                  file_error_details = BuildInstallDetails(
+                     effect,
+                     model_info->model_name,
+                     "Download",
+                     "wxFile reported an error while writing the downloaded data.",
+                     fullFilePath.GetFullPath().ToStdString(),
+                     "wxFile last error: " + std::to_string(last_error) + "\nSource URL: " + url);
                   bError = true;
                   response->Cancel();
                   return;
@@ -268,6 +367,14 @@ static void download_model_files(std::shared_ptr<OVModelManager::ModelInfo> mode
                if (bytesWritten != responseData.size())
                {
                   std::cout << "uh oh... bytesWritten != responseData.size() " << std::endl;
+                  file_error_summary = "Incomplete model file write detected.";
+                  file_error_details = BuildInstallDetails(
+                     effect,
+                     model_info->model_name,
+                     "Download",
+                     "The downloaded data size did not match the number of bytes written to disk.",
+                     fullFilePath.GetFullPath().ToStdString(),
+                     "Bytes written: " + std::to_string(bytesWritten) + "\nBytes received: " + std::to_string(responseData.size()) + "\nSource URL: " + url);
                   bError = true;
                   response->Cancel();
                   return;
@@ -276,6 +383,14 @@ static void download_model_files(std::shared_ptr<OVModelManager::ModelInfo> mode
             else
             {
                std::cout << "uh oh... httpCode = " << httpCode << std::endl;
+               file_error_summary = "Model download returned an unexpected HTTP status.";
+               file_error_details = BuildInstallDetails(
+                  effect,
+                  model_info->model_name,
+                  "Download",
+                  "GET request returned an unexpected HTTP status.",
+                  url,
+                  "HTTP status: " + std::to_string(httpCode));
                bError = true;
                response->Cancel();
                return;
@@ -296,23 +411,30 @@ static void download_model_files(std::shared_ptr<OVModelManager::ModelInfo> mode
       //wait for request to complete.
       doneFuture.get();
 
-      if (bError)
-         break;
+      if (bError) {
+         return OVModelManager::InstallResult::Failure(file_error_summary, file_error_details);
+      }
 
       std::cout << "finished downloading " << url << std::endl;
    }
+
+   return OVModelManager::InstallResult::Success();
 #else
-   throw std::runtime_error("download_model_files called, but this build has no networking support!");
+   return OVModelManager::InstallResult::Failure(
+      "Model downloads are not available in this build.",
+      BuildInstallDetails(effect, model_info ? model_info->model_name : std::string{}, "Download", "download_model_files called, but this build has no networking support."));
 #endif
 }
 
-void OVModelManager::install_model(std::string effect, std::string model_id, ProgressCallback callback)
+OVModelManager::InstallResult OVModelManager::install_model(std::string effect, std::string model_id, ProgressCallback callback)
 {
    try {
       auto it = mModelCollection.find(effect);
       if (it == mModelCollection.end()) {
          std::cout << "Model Collection for effect=" << effect << " not found." << std::endl;
-         return;
+         return InstallResult::Failure(
+            "Model install failed before download started.",
+            BuildInstallDetails(effect, model_id, "Lookup", "No model collection was found for the requested effect."));
       }
 
       std::shared_ptr<ModelInfo> model_info;
@@ -327,15 +449,28 @@ void OVModelManager::install_model(std::string effect, std::string model_id, Pro
 
       if (!bFound) {
          std::cout << "Model Info for model_id=" << model_id << " not found." << std::endl;
-         return;
+         return InstallResult::Failure(
+            "Model install failed before download started.",
+            BuildInstallDetails(effect, model_id, "Lookup", "No model info entry was found for the requested model."));
       }
 
-      size_t total_download_size = install_model_size(model_info);
-
-      if (total_download_size == 0)
+      size_t total_download_size = 0;
+      auto sizeResult = install_model_size(model_info, total_download_size);
+      if (!sizeResult)
       {
          std::cout << "install_model_size failed." << std::endl;
-         return;
+         return WrapInstallFailure(
+            effect,
+            model_id,
+            "Size Check",
+            "Could not determine how much data must be downloaded for this model.",
+            sizeResult);
+      }
+
+      if (mSearchPaths.empty()) {
+         return InstallResult::Failure(
+            "Model install failed before download started.",
+            BuildInstallDetails(effect, model_id, "Path Setup", "No model installation directory is configured."));
       }
 
       auto& base_openvino_models_path = mSearchPaths[0];
@@ -348,11 +483,18 @@ void OVModelManager::install_model(std::string effect, std::string model_id, Pro
       // add the total size of the dependencies.
       for (auto& d : model_info->dependencies) {
          if (!d->installed) {
-            size_t dependencies_size = install_model_size(d);
-            if (dependencies_size == 0)
+            size_t dependencies_size = 0;
+            auto dependencySizeResult = install_model_size(d, dependencies_size);
+            if (!dependencySizeResult)
             {
                std::cout << "install_model_size failed for dependencies: " << d->model_name << std::endl;
-               return;
+               return WrapInstallFailure(
+                  effect,
+                  model_id,
+                  "Dependency Size Check",
+                  "Could not determine how much data must be downloaded for a dependency.",
+                  dependencySizeResult,
+                  d->model_name);
             }
 
             total_download_size += dependencies_size;
@@ -366,10 +508,23 @@ void OVModelManager::install_model(std::string effect, std::string model_id, Pro
       if (!model_info->dependencies.empty()) {
          for (auto& d : model_info->dependencies) {
             if (!d->installed) {
-               download_model_files(d, base_openvino_models_path, total_download_size, bytes_downloaded_so_far, callback);
+               auto dependencyDownloadResult = download_model_files(effect, d, base_openvino_models_path, total_download_size, bytes_downloaded_so_far, callback);
+               if (!dependencyDownloadResult) {
+                  return WrapInstallFailure(
+                     effect,
+                     model_id,
+                     "Dependency Download",
+                     "A required dependency failed to download.",
+                     dependencyDownloadResult,
+                     d->model_name);
+               }
+
                _check_installed_model_impl(d, base_openvino_models_path);
-               if (!d->installed)
-                  return;
+               if (!d->installed) {
+                  return InstallResult::Failure(
+                     "A required dependency did not verify after download.",
+                     BuildInstallDetails(effect, model_id, "Dependency Verification", "Downloaded dependency files were not found during post-download verification.", d->model_name));
+               }
             }
             else
             {
@@ -378,7 +533,10 @@ void OVModelManager::install_model(std::string effect, std::string model_id, Pro
          }
       }
 
-      download_model_files(model_info, base_openvino_models_path, total_download_size, bytes_downloaded_so_far, callback);
+      auto downloadResult = download_model_files(effect, model_info, base_openvino_models_path, total_download_size, bytes_downloaded_so_far, callback);
+      if (!downloadResult) {
+         return downloadResult;
+      }
 
       //re-run file check for this model.
       _check_installed_model_impl(model_info, base_openvino_models_path);
@@ -389,11 +547,20 @@ void OVModelManager::install_model(std::string effect, std::string model_id, Pro
          {
             callback_it->second(model_info->model_name);
          }
+
+         return InstallResult::Success();
       }
+
+      return InstallResult::Failure(
+         "Model files did not verify after download.",
+         BuildInstallDetails(effect, model_id, "Verification", "Download completed, but the expected installed files were not found in the target directory.", base_openvino_models_path.ToStdString()));
    }
    catch (const std::exception& error) {
       std::cout << "install_model: exception caught for model_id = " << model_id << std::endl;
       std::cout << "exception details: " << error.what() << std::endl;
+      return InstallResult::Failure(
+         "Unexpected exception while installing the model.",
+         BuildInstallDetails(effect, model_id, "Exception", "install_model caught an unexpected exception.", {}, error.what()));
    }
 }
 

--- a/mod-openvino/OVModelManager.cpp
+++ b/mod-openvino/OVModelManager.cpp
@@ -309,7 +309,7 @@ static OVModelManager::InstallResult download_model_files(const std::string& eff
 
       // write to file here
       response->setOnDataReceivedCallback(
-         [response, wx_file, &bError, &bytes_downloaded_so_far, callback, &total_download_size, &file_error_summary, &file_error_details, &effect, model_info, &url, fullFilePath](audacity::network_manager::IResponse*)
+         [response, wx_file, &bError, &bytes_downloaded_so_far, callback, &total_download_size, &file_error_summary, &file_error_details, &effect, model_info, url, fullFilePath](audacity::network_manager::IResponse*)
          {
             // only attempt save if request succeeded
             int httpCode = response->getHTTPCode();
@@ -437,7 +437,7 @@ OVModelManager::InstallResult OVModelManager::install_model(std::string effect, 
       auto sizeResult = install_model_size(model_info, total_download_size);
       if (!sizeResult)
       {
-         wxLogError("OVModelManager: install_model_size failed for model '%s'.", model_id);
+         wxLogError("OVModelManager: install_model_size failed for model '%s'.", model_id.c_str());
          return WrapInstallFailure(
             effect,
             model_id,

--- a/mod-openvino/OVModelManager.cpp
+++ b/mod-openvino/OVModelManager.cpp
@@ -309,7 +309,7 @@ static OVModelManager::InstallResult download_model_files(const std::string& eff
 
       // write to file here
       response->setOnDataReceivedCallback(
-         [response, wx_file, &bError, &bytes_downloaded_so_far, callback, &total_download_size, &file_error_summary, &file_error_details, &effect, model_info, url, fullFilePath](audacity::network_manager::IResponse*)
+         [response, wx_file, &bError, &bytes_downloaded_so_far, callback, &total_download_size, &file_error_summary, &file_error_details, &effect, model_info, &url, fullFilePath](audacity::network_manager::IResponse*)
          {
             // only attempt save if request succeeded
             int httpCode = response->getHTTPCode();
@@ -437,7 +437,7 @@ OVModelManager::InstallResult OVModelManager::install_model(std::string effect, 
       auto sizeResult = install_model_size(model_info, total_download_size);
       if (!sizeResult)
       {
-         wxLogError("OVModelManager: install_model_size failed for model '%s'.", model_id.c_str());
+         wxLogError("OVModelManager: install_model_size failed for model '%s'.", model_id);
          return WrapInstallFailure(
             effect,
             model_id,

--- a/mod-openvino/OVModelManager.cpp
+++ b/mod-openvino/OVModelManager.cpp
@@ -201,7 +201,7 @@ OVModelManager::InstallResult OVModelManager::install_model_size(std::shared_ptr
          request = audacity::network_manager::Request(url);
       }
       catch (const std::exception& error) {
-         wxLogError("OVModelManager: failed to create HEAD request for URL '%s'. Exception: %s", url, error.what());
+         wxLogError("OVModelManager: failed to create HEAD request for URL '%s'. Exception: %s", url.c_str(), error.what());
          return InstallResult::Failure(
             "Could not create a download request.",
             BuildInstallDetails({}, model_info->model_name, "Size Check", "Could not create a HEAD request for model download size lookup.", url, error.what()));
@@ -216,7 +216,7 @@ OVModelManager::InstallResult OVModelManager::install_model_size(std::shared_ptr
          }
 
          if ((response->getHTTPCode() != 200) && (response->getHTTPCode() != 302)) {
-            wxLogError("OVModelManager: unexpected HTTP status %d while fetching HEAD for URL '%s'.", response->getHTTPCode(), url);
+            wxLogError("OVModelManager: unexpected HTTP status %d while fetching HEAD for URL '%s'.", response->getHTTPCode(), url.c_str());
             return InstallResult::Failure(
                "Could not retrieve model download metadata.",
                BuildInstallDetails({}, model_info->model_name, "Size Check", "HEAD request returned an unexpected HTTP status.", url, "HTTP status: " + std::to_string(response->getHTTPCode())));
@@ -239,14 +239,14 @@ OVModelManager::InstallResult OVModelManager::install_model_size(std::shared_ptr
 
          if (!size_header_found)
          {
-            wxLogError("OVModelManager: response missing X-Linked-Size and Content-Length headers for URL '%s'.", url);
+            wxLogError("OVModelManager: response missing X-Linked-Size and Content-Length headers for URL '%s'.", url.c_str());
             return InstallResult::Failure(
                "Could not determine model download size.",
                BuildInstallDetails({}, model_info->model_name, "Size Check", "Response did not include X-Linked-Size or Content-Length.", url));
          }
       }
       catch (const std::exception& error) {
-         wxLogError("OVModelManager: exception while reading HEAD response for URL '%s'. Exception: %s", url, error.what());
+         wxLogError("OVModelManager: exception while reading HEAD response for URL '%s'. Exception: %s", url.c_str(), error.what());
          return InstallResult::Failure(
             "Could not retrieve model download metadata.",
             BuildInstallDetails({}, model_info->model_name, "Size Check", "Exception while reading HEAD response for size calculation.", url, error.what()));
@@ -363,7 +363,7 @@ static OVModelManager::InstallResult download_model_files(const std::string& eff
             }
             else
             {
-               wxLogError("OVModelManager: GET request returned unexpected HTTP status %d for URL '%s'.", httpCode, url);
+               wxLogError("OVModelManager: GET request returned unexpected HTTP status %d for URL '%s'.", httpCode, url.c_str());
                file_error_summary = "Model download returned an unexpected HTTP status.";
                file_error_details = BuildInstallDetails(
                   effect,
@@ -410,7 +410,7 @@ OVModelManager::InstallResult OVModelManager::install_model(std::string effect, 
    try {
       auto it = mModelCollection.find(effect);
       if (it == mModelCollection.end()) {
-         wxLogError("OVModelManager: model collection for effect '%s' not found.", effect);
+         wxLogError("OVModelManager: model collection for effect '%s' not found.", effect.c_str());
          return InstallResult::Failure(
             "Model install failed before download started.",
             BuildInstallDetails(effect, model_id, "Lookup", "No model collection was found for the requested effect."));
@@ -427,7 +427,7 @@ OVModelManager::InstallResult OVModelManager::install_model(std::string effect, 
       }
 
       if (!bFound) {
-         wxLogError("OVModelManager: model info for model_id '%s' not found.", model_id);
+         wxLogError("OVModelManager: model info for model_id '%s' not found.", model_id.c_str());
          return InstallResult::Failure(
             "Model install failed before download started.",
             BuildInstallDetails(effect, model_id, "Lookup", "No model info entry was found for the requested model."));
@@ -466,7 +466,7 @@ OVModelManager::InstallResult OVModelManager::install_model(std::string effect, 
             auto dependencySizeResult = install_model_size(d, dependencies_size);
             if (!dependencySizeResult)
             {
-               wxLogError("OVModelManager: install_model_size failed for dependency '%s'.", d->model_name);
+               wxLogError("OVModelManager: install_model_size failed for dependency '%s'.", d->model_name.c_str());
                return WrapInstallFailure(
                   effect,
                   model_id,
@@ -529,7 +529,7 @@ OVModelManager::InstallResult OVModelManager::install_model(std::string effect, 
          BuildInstallDetails(effect, model_id, "Verification", "Download completed, but the expected installed files were not found in the target directory.", base_openvino_models_path.ToStdString()));
    }
    catch (const std::exception& error) {
-      wxLogError("OVModelManager: exception while installing model '%s'. Exception: %s", model_id, error.what());
+      wxLogError("OVModelManager: exception while installing model '%s'. Exception: %s", model_id.c_str(), error.what());
       return InstallResult::Failure(
          "Unexpected exception while installing the model.",
          BuildInstallDetails(effect, model_id, "Exception", "install_model caught an unexpected exception.", {}, error.what()));

--- a/mod-openvino/OVModelManager.cpp
+++ b/mod-openvino/OVModelManager.cpp
@@ -437,7 +437,7 @@ OVModelManager::InstallResult OVModelManager::install_model(std::string effect, 
       auto sizeResult = install_model_size(model_info, total_download_size);
       if (!sizeResult)
       {
-         wxLogError("OVModelManager: install_model_size failed for model '%s'.", model_id);
+         wxLogError("OVModelManager: install_model_size failed for model '%s'.", model_id.c_str());
          return WrapInstallFailure(
             effect,
             model_id,

--- a/mod-openvino/OVModelManager.h
+++ b/mod-openvino/OVModelManager.h
@@ -1,7 +1,10 @@
 #pragma once
+#include <functional>
+#include <memory>
 #include <unordered_map>
 #include <string>
-#include <memory>
+#include <utility>
+#include <vector>
 #include <FileNames.h>
 
 class OVModelManager {
@@ -47,6 +50,25 @@ public:
       std::vector< std::shared_ptr<ModelInfo> > models;
    };
 
+   struct InstallResult
+   {
+      bool succeeded = false;
+      std::string summary;
+      std::string details;
+
+      explicit operator bool() const { return succeeded; }
+
+      static InstallResult Success()
+      {
+         return { true, {}, {} };
+      }
+
+      static InstallResult Failure(std::string summary, std::string details)
+      {
+         return { false, std::move(summary), std::move(details) };
+      }
+   };
+
    // strings to be passed into various functions below that take 'effect' as parameter.
    static const std::string MusicSepName() { return "Music Separation"; };
    static const std::string NoiseSuppressName() { return "Noise Suppression"; }
@@ -63,8 +85,8 @@ public:
    std::shared_ptr<ModelCollection> GetModelCollection(const std::string& effect);
 
    using ProgressCallback = std::function<void(float)>;
-   void install_model(std::string effect, std::string model_id, ProgressCallback callback = nullptr);
-   size_t install_model_size(std::shared_ptr<ModelInfo> model_info);
+   InstallResult install_model(std::string effect, std::string model_id, ProgressCallback callback = nullptr);
+   InstallResult install_model_size(std::shared_ptr<ModelInfo> model_info, size_t& total_size);
 
    using InstalledCallback = std::function<void(const std::string &model_name)>;
    void register_installed_callback(const std::string& effect, InstalledCallback callback);

--- a/mod-openvino/OVModelManagerUI.cpp
+++ b/mod-openvino/OVModelManagerUI.cpp
@@ -355,17 +355,17 @@ void ModelManagerDialog::QueueInstall(ModelEntryPanel* panel) {
       StartNextInstall();
 }
 
-void ModelManagerDialog::BeginInstallFor(ModelEntryPanel* panel) {
-   std::thread([this, panel]() {
+void ModelManagerDialog::BeginInstallFor(ModelEntryPanel* panel, InstallQueueEntryPanel* queueEntry) {
+   std::thread([this, panel, queueEntry]() {
 
       auto effect = panel->GetEffect();
       auto model_name = panel->GetModel()->model_name;
 
       OVModelManager::ProgressCallback callback =
-         [this](float perc_complete) {
+         [this, queueEntry](float perc_complete) {
          wxTheApp->CallAfter([=]() {
-            if (activeQueueEntry)
-               activeQueueEntry->UpdateProgress(static_cast<int>(perc_complete * 100));
+            if (queueEntry)
+               queueEntry->UpdateProgress(static_cast<int>(perc_complete * 100));
             });
          };
 
@@ -373,22 +373,27 @@ void ModelManagerDialog::BeginInstallFor(ModelEntryPanel* panel) {
 
       wxTheApp->CallAfter([=]() {
          if (installResult) {
-            activeInstall->SetInstalled();
+            panel->SetInstalled();
 
-            auto* completedPanel = activeQueueEntry;
-            if (completedPanel) {
-               RemoveQueueEntry(completedPanel);
+            if (queueEntry) {
+               RemoveQueueEntry(queueEntry);
             }
          }
          else {
-            activeInstall->SetFailed(wxString(installResult.summary));
-            if (activeQueueEntry) {
-               activeQueueEntry->SetAsFailed(installResult);
+            panel->SetFailed(wxString(installResult.summary));
+            if (queueEntry) {
+               queueEntry->SetAsFailed(installResult);
             }
          }
 
-         activeInstall = nullptr;
-         activeQueueEntry = nullptr;
+         if (activeInstall == panel) {
+            activeInstall = nullptr;
+         }
+
+         if (activeQueueEntry == queueEntry) {
+            activeQueueEntry = nullptr;
+         }
+
          StartNextInstall();  // recursively process queue
          });
       }).detach();
@@ -406,7 +411,7 @@ void ModelManagerDialog::StartNextInstall() {
       activeQueueEntry->SetAsInstalling();
    }
 
-   BeginInstallFor(activeInstall);
+   BeginInstallFor(activeInstall, activeQueueEntry);
 
    queueSizer->Layout();
    Layout();

--- a/mod-openvino/OVModelManagerUI.cpp
+++ b/mod-openvino/OVModelManagerUI.cpp
@@ -210,7 +210,7 @@ void InstallQueueEntryPanel::SetAsQueued() {
    label->SetLabel(modelPanel->GetModel()->model_name + " (Queued)");
    label->SetForegroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT));
    gauge->Hide();
-    detailsButton->Disable();
+   detailsButton->Disable();
    detailsButton->SetToolTip({});
    Layout();
 }
@@ -296,7 +296,7 @@ ModelManagerDialog::ModelManagerDialog(wxWindow* parent)
    for (const auto& s : allSections) {
       auto collection = OVModelManager::instance().GetModelCollection(s);
       if (collection->models.empty()) {
-         wxLogInfo("OVModelManagerUI: skipping empty model collection section '%s'.", s);
+         wxLogInfo("OVModelManagerUI: skipping empty model collection section '%s'.", s.c_str());
          continue;
       }
 

--- a/mod-openvino/OVModelManagerUI.cpp
+++ b/mod-openvino/OVModelManagerUI.cpp
@@ -9,6 +9,7 @@
 #include <wx/regex.h>
 #include <wx/settings.h>
 #include <wx/textctrl.h>
+#include <wx/weakref.h>
 
 class ModelCardDialog : public wxDialog {
 public:
@@ -218,7 +219,7 @@ void InstallQueueEntryPanel::SetAsQueued() {
 void InstallQueueEntryPanel::SetAsFailed(const OVModelManager::InstallResult& result) {
    installResult = result;
    label->SetLabel(modelPanel->GetModel()->model_name + " (Failed)");
-   label->SetForegroundColour(wxColour(160, 0, 0));
+   label->SetForegroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT));
    gauge->Hide();
    detailsButton->Enable();
    detailsButton->SetToolTip(result.summary);
@@ -356,47 +357,69 @@ void ModelManagerDialog::QueueInstall(ModelEntryPanel* panel) {
 }
 
 void ModelManagerDialog::BeginInstallFor(ModelEntryPanel* panel, InstallQueueEntryPanel* queueEntry) {
-   std::thread([this, panel, queueEntry]() {
+   // Capture required model information while the panel is known to be valid.
+   auto effect = panel->GetEffect();
+   auto model_name = panel->GetModel()->model_name;
 
-      auto effect = panel->GetEffect();
-      auto model_name = panel->GetModel()->model_name;
+   // Use weak references so that callbacks can safely skip UI updates
+   // if the dialog or panels have been destroyed.
+   wxWeakRef<ModelManagerDialog> dlgRef(this);
+   wxWeakRef<ModelEntryPanel> panelRef(panel);
+   wxWeakRef<InstallQueueEntryPanel> queueRef(queueEntry);
+
+   std::thread([dlgRef, panelRef, queueRef, effect, model_name]() {
 
       OVModelManager::ProgressCallback callback =
-         [this, queueEntry](float perc_complete) {
-         wxTheApp->CallAfter([=]() {
-            if (queueEntry)
-               queueEntry->UpdateProgress(static_cast<int>(perc_complete * 100));
+         [dlgRef, queueRef](float perc_complete) {
+            wxTheApp->CallAfter([dlgRef, queueRef, perc_complete]() {
+               ModelManagerDialog* dlg = dlgRef.get();
+               InstallQueueEntryPanel* queueEntryPtr = queueRef.get();
+
+               if (!dlg || !queueEntryPtr) {
+                  return;
+               }
+
+               queueEntryPtr->UpdateProgress(static_cast<int>(perc_complete * 100));
             });
          };
 
       const auto installResult = OVModelManager::instance().install_model(effect, model_name, callback);
 
-      wxTheApp->CallAfter([=]() {
-         if (installResult) {
-            panel->SetInstalled();
+      wxTheApp->CallAfter([dlgRef, panelRef, queueRef, installResult]() {
+         ModelManagerDialog* dlg = dlgRef.get();
+         ModelEntryPanel* panelPtr = panelRef.get();
+         InstallQueueEntryPanel* queueEntryPtr = queueRef.get();
 
-            if (queueEntry) {
-               RemoveQueueEntry(queueEntry);
+         // If the dialog or model panel no longer exist, skip UI updates.
+         if (!dlg || !panelPtr) {
+            return;
+         }
+
+         if (installResult) {
+            panelPtr->SetInstalled();
+
+            if (queueEntryPtr) {
+               dlg->RemoveQueueEntry(queueEntryPtr);
             }
          }
          else {
-            panel->SetFailed(wxString(installResult.summary));
-            if (queueEntry) {
-               queueEntry->SetAsFailed(installResult);
+            panelPtr->SetFailed(wxString(installResult.summary));
+            if (queueEntryPtr) {
+               queueEntryPtr->SetAsFailed(installResult);
             }
          }
 
-         if (activeInstall == panel) {
-            activeInstall = nullptr;
+         if (dlg->activeInstall == panelPtr) {
+            dlg->activeInstall = nullptr;
          }
 
-         if (activeQueueEntry == queueEntry) {
-            activeQueueEntry = nullptr;
+         if (dlg->activeQueueEntry == queueEntryPtr) {
+            dlg->activeQueueEntry = nullptr;
          }
 
-         StartNextInstall();  // recursively process queue
-         });
-      }).detach();
+         dlg->StartNextInstall();  // recursively process queue
+      });
+   }).detach();
 }
 
 void ModelManagerDialog::StartNextInstall() {

--- a/mod-openvino/OVModelManagerUI.cpp
+++ b/mod-openvino/OVModelManagerUI.cpp
@@ -9,7 +9,6 @@
 #include <wx/regex.h>
 #include <wx/settings.h>
 #include <wx/textctrl.h>
-#include <wx/weakref.h>
 
 class ModelCardDialog : public wxDialog {
 public:
@@ -219,7 +218,7 @@ void InstallQueueEntryPanel::SetAsQueued() {
 void InstallQueueEntryPanel::SetAsFailed(const OVModelManager::InstallResult& result) {
    installResult = result;
    label->SetLabel(modelPanel->GetModel()->model_name + " (Failed)");
-   label->SetForegroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT));
+   label->SetForegroundColour(wxColour(160, 0, 0));
    gauge->Hide();
    detailsButton->Enable();
    detailsButton->SetToolTip(result.summary);
@@ -357,69 +356,47 @@ void ModelManagerDialog::QueueInstall(ModelEntryPanel* panel) {
 }
 
 void ModelManagerDialog::BeginInstallFor(ModelEntryPanel* panel, InstallQueueEntryPanel* queueEntry) {
-   // Capture required model information while the panel is known to be valid.
-   auto effect = panel->GetEffect();
-   auto model_name = panel->GetModel()->model_name;
+   std::thread([this, panel, queueEntry]() {
 
-   // Use weak references so that callbacks can safely skip UI updates
-   // if the dialog or panels have been destroyed.
-   wxWeakRef<ModelManagerDialog> dlgRef(this);
-   wxWeakRef<ModelEntryPanel> panelRef(panel);
-   wxWeakRef<InstallQueueEntryPanel> queueRef(queueEntry);
-
-   std::thread([dlgRef, panelRef, queueRef, effect, model_name]() {
+      auto effect = panel->GetEffect();
+      auto model_name = panel->GetModel()->model_name;
 
       OVModelManager::ProgressCallback callback =
-         [dlgRef, queueRef](float perc_complete) {
-            wxTheApp->CallAfter([dlgRef, queueRef, perc_complete]() {
-               ModelManagerDialog* dlg = dlgRef.get();
-               InstallQueueEntryPanel* queueEntryPtr = queueRef.get();
-
-               if (!dlg || !queueEntryPtr) {
-                  return;
-               }
-
-               queueEntryPtr->UpdateProgress(static_cast<int>(perc_complete * 100));
+         [this, queueEntry](float perc_complete) {
+         wxTheApp->CallAfter([=]() {
+            if (queueEntry)
+               queueEntry->UpdateProgress(static_cast<int>(perc_complete * 100));
             });
          };
 
       const auto installResult = OVModelManager::instance().install_model(effect, model_name, callback);
 
-      wxTheApp->CallAfter([dlgRef, panelRef, queueRef, installResult]() {
-         ModelManagerDialog* dlg = dlgRef.get();
-         ModelEntryPanel* panelPtr = panelRef.get();
-         InstallQueueEntryPanel* queueEntryPtr = queueRef.get();
-
-         // If the dialog or model panel no longer exist, skip UI updates.
-         if (!dlg || !panelPtr) {
-            return;
-         }
-
+      wxTheApp->CallAfter([=]() {
          if (installResult) {
-            panelPtr->SetInstalled();
+            panel->SetInstalled();
 
-            if (queueEntryPtr) {
-               dlg->RemoveQueueEntry(queueEntryPtr);
+            if (queueEntry) {
+               RemoveQueueEntry(queueEntry);
             }
          }
          else {
-            panelPtr->SetFailed(wxString(installResult.summary));
-            if (queueEntryPtr) {
-               queueEntryPtr->SetAsFailed(installResult);
+            panel->SetFailed(wxString(installResult.summary));
+            if (queueEntry) {
+               queueEntry->SetAsFailed(installResult);
             }
          }
 
-         if (dlg->activeInstall == panelPtr) {
-            dlg->activeInstall = nullptr;
+         if (activeInstall == panel) {
+            activeInstall = nullptr;
          }
 
-         if (dlg->activeQueueEntry == queueEntryPtr) {
-            dlg->activeQueueEntry = nullptr;
+         if (activeQueueEntry == queueEntry) {
+            activeQueueEntry = nullptr;
          }
 
-         dlg->StartNextInstall();  // recursively process queue
-      });
-   }).detach();
+         StartNextInstall();  // recursively process queue
+         });
+      }).detach();
 }
 
 void ModelManagerDialog::StartNextInstall() {

--- a/mod-openvino/OVModelManagerUI.cpp
+++ b/mod-openvino/OVModelManagerUI.cpp
@@ -5,6 +5,7 @@
 #include <wx/clipbrd.h>
 #include <wx/dataobj.h>
 #include <wx/html/htmlwin.h>
+#include <wx/log.h>
 #include <wx/regex.h>
 #include <wx/settings.h>
 #include <wx/textctrl.h>
@@ -295,7 +296,7 @@ ModelManagerDialog::ModelManagerDialog(wxWindow* parent)
    for (const auto& s : allSections) {
       auto collection = OVModelManager::instance().GetModelCollection(s);
       if (collection->models.empty()) {
-         std::cout << "Empty collection for section=" << s << std::endl;
+         wxLogInfo("OVModelManagerUI: skipping empty model collection section '%s'.", s);
          continue;
       }
 

--- a/mod-openvino/OVModelManagerUI.cpp
+++ b/mod-openvino/OVModelManagerUI.cpp
@@ -362,6 +362,10 @@ void ModelManagerDialog::QueueInstall(ModelEntryPanel* panel) {
 }
 
 void ModelManagerDialog::BeginInstallFor(ModelEntryPanel* panel, InstallQueueEntryPanel* queueEntry) {
+   if (!panel) {
+      wxLogError("BeginInstallFor called with null ModelEntryPanel");
+      return;
+   }
    const int panelId = panel ? panel->GetId() : wxID_NONE;
    const int queueEntryId = queueEntry ? queueEntry->GetId() : wxID_NONE;
    const auto effect = panel->GetEffect();
@@ -415,7 +419,7 @@ void ModelManagerDialog::BeginInstallFor(ModelEntryPanel* panel, InstallQueueEnt
          }
          else {
             if (panelIsValid) {
-               livePanel->SetFailed(wxString(installResult.summary));
+               livePanel->SetFailed(wxString::FromUTF8(installResult.summary.c_str()));
             }
 
             if (queueEntryIsValid) {

--- a/mod-openvino/OVModelManagerUI.cpp
+++ b/mod-openvino/OVModelManagerUI.cpp
@@ -336,6 +336,12 @@ ModelManagerDialog::ModelManagerDialog(wxWindow* parent)
    OVModelManager& model_manager = OVModelManager::instance();
 }
 
+ModelManagerDialog::~ModelManagerDialog() {
+   if (instance == this) {
+      instance = nullptr;
+   }
+}
+
 void ModelManagerDialog::QueueInstall(ModelEntryPanel* panel) {
    if (auto* existingEntry = FindQueueEntry(panel)) {
       RemoveQueueEntry(existingEntry);
@@ -356,18 +362,26 @@ void ModelManagerDialog::QueueInstall(ModelEntryPanel* panel) {
 }
 
 void ModelManagerDialog::BeginInstallFor(ModelEntryPanel* panel, InstallQueueEntryPanel* queueEntry) {
-   const auto queueEntryRaw = queueEntry;
+   const int panelId = panel ? panel->GetId() : wxID_NONE;
    const int queueEntryId = queueEntry ? queueEntry->GetId() : wxID_NONE;
+   const auto effect = panel->GetEffect();
+   const auto model_name = panel->GetModel()->model_name;
 
-   std::thread([this, panel, queueEntryRaw, queueEntryId]() {
-
-      auto effect = panel->GetEffect();
-      auto model_name = panel->GetModel()->model_name;
+   std::thread([panelId, queueEntryId, effect, model_name]() {
 
       OVModelManager::ProgressCallback callback =
-         [this, queueEntryId](float perc_complete) {
-         wxTheApp->CallAfter([this, queueEntryId, perc_complete]() {
-            auto* liveQueueEntry = FindQueueEntryById(queueEntryId);
+         [panelId, queueEntryId](float perc_complete) {
+         wxTheApp->CallAfter([panelId, queueEntryId, perc_complete]() {
+            auto* dialog = ModelManagerDialog::instance;
+            if (!dialog || dialog->IsBeingDeleted()) {
+               return;
+            }
+
+            if (!dialog->activeInstall || dialog->activeInstall->GetId() != panelId) {
+               return;
+            }
+
+            auto* liveQueueEntry = dialog->FindQueueEntryById(queueEntryId);
             if (!liveQueueEntry || liveQueueEntry->IsBeingDeleted()) {
                return;
             }
@@ -378,35 +392,62 @@ void ModelManagerDialog::BeginInstallFor(ModelEntryPanel* panel, InstallQueueEnt
 
       const auto installResult = OVModelManager::instance().install_model(effect, model_name, callback);
 
-      wxTheApp->CallAfter([this, panel, queueEntryRaw, queueEntryId, installResult]() {
-         auto* liveQueueEntry = FindQueueEntryById(queueEntryId);
+      wxTheApp->CallAfter([panelId, queueEntryId, installResult]() {
+         auto* dialog = ModelManagerDialog::instance;
+         if (!dialog || dialog->IsBeingDeleted()) {
+            return;
+         }
+
+         auto* livePanel = dialog->FindModelPanelById(panelId);
+         const bool panelIsValid = livePanel && !livePanel->IsBeingDeleted();
+
+         auto* liveQueueEntry = dialog->FindQueueEntryById(queueEntryId);
          const bool queueEntryIsValid = liveQueueEntry && !liveQueueEntry->IsBeingDeleted();
 
          if (installResult) {
-            panel->SetInstalled();
+            if (panelIsValid) {
+               livePanel->SetInstalled();
+            }
 
             if (queueEntryIsValid) {
-               RemoveQueueEntry(liveQueueEntry);
+               dialog->RemoveQueueEntry(liveQueueEntry);
             }
          }
          else {
-            panel->SetFailed(wxString(installResult.summary));
+            if (panelIsValid) {
+               livePanel->SetFailed(wxString(installResult.summary));
+            }
+
             if (queueEntryIsValid) {
                liveQueueEntry->SetAsFailed(installResult);
             }
          }
 
-         if (activeInstall == panel) {
-            activeInstall = nullptr;
+         if (dialog->activeInstall && dialog->activeInstall->GetId() == panelId) {
+            dialog->activeInstall = nullptr;
          }
 
-         if (activeQueueEntry == queueEntryRaw) {
-            activeQueueEntry = nullptr;
+         if (dialog->activeQueueEntry && dialog->activeQueueEntry->GetId() == queueEntryId) {
+            dialog->activeQueueEntry = nullptr;
          }
 
-         StartNextInstall();  // recursively process queue
+         dialog->StartNextInstall();  // recursively process queue
          });
       }).detach();
+}
+
+ModelEntryPanel* ModelManagerDialog::FindModelPanelById(int panelId) const {
+   if (panelId == wxID_NONE) {
+      return nullptr;
+   }
+
+   for (auto* panel : allPanels) {
+      if (panel && panel->GetId() == panelId) {
+         return panel;
+      }
+   }
+
+   return nullptr;
 }
 
 void ModelManagerDialog::StartNextInstall() {
@@ -454,6 +495,10 @@ InstallQueueEntryPanel* ModelManagerDialog::FindQueueEntryById(int entryId) cons
 void ModelManagerDialog::RemoveQueueEntry(InstallQueueEntryPanel* entry) {
    if (!entry) {
       return;
+   }
+
+   if (activeQueueEntry == entry) {
+      activeQueueEntry = nullptr;
    }
 
    queueSizer->Detach(entry);

--- a/mod-openvino/OVModelManagerUI.cpp
+++ b/mod-openvino/OVModelManagerUI.cpp
@@ -1,8 +1,13 @@
 #include "OVModelManagerUI.h"
 #include "OpenVINOPluginPrefs.h"
+#include <algorithm>
 #include <thread>
+#include <wx/clipbrd.h>
+#include <wx/dataobj.h>
 #include <wx/html/htmlwin.h>
 #include <wx/regex.h>
+#include <wx/settings.h>
+#include <wx/textctrl.h>
 
 class ModelCardDialog : public wxDialog {
 public:
@@ -29,6 +34,44 @@ public:
       sizer->Add(closeBtn, 0, wxALIGN_RIGHT | wxALL, 10);
 
       SetSizer(sizer);
+      Layout();
+      CentreOnParent();
+   }
+};
+
+class InstallFailureDialog : public wxDialog {
+public:
+   InstallFailureDialog(wxWindow* parent, const wxString& title, const wxString& details)
+      : wxDialog(parent, wxID_ANY, title, wxDefaultPosition, wxSize(700, 420),
+         wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER)
+   {
+      wxBoxSizer* mainSizer = new wxBoxSizer(wxVERTICAL);
+
+      auto* detailsText = new wxTextCtrl(
+         this,
+         wxID_ANY,
+         details,
+         wxDefaultPosition,
+         wxDefaultSize,
+         wxTE_MULTILINE | wxTE_READONLY | wxTE_DONTWRAP);
+      mainSizer->Add(detailsText, 1, wxEXPAND | wxALL, 10);
+
+      wxBoxSizer* buttonSizer = new wxBoxSizer(wxHORIZONTAL);
+      auto* copyButton = new wxButton(this, wxID_ANY, "Copy Details");
+      auto* closeButton = new wxButton(this, wxID_OK, "Close");
+
+      copyButton->Bind(wxEVT_BUTTON, [details, this](wxCommandEvent&) {
+         if (wxTheClipboard && wxTheClipboard->Open()) {
+            wxTheClipboard->SetData(new wxTextDataObject(details));
+            wxTheClipboard->Close();
+         }
+      });
+
+      buttonSizer->Add(copyButton, 0, wxRIGHT, 8);
+      buttonSizer->Add(closeButton, 0);
+      mainSizer->Add(buttonSizer, 0, wxALIGN_RIGHT | wxLEFT | wxRIGHT | wxBOTTOM, 10);
+
+      SetSizer(mainSizer);
       Layout();
       CentreOnParent();
    }
@@ -93,11 +136,13 @@ void ModelEntryPanel::UpdateStatus() {
    if (restartRequired && !model->installed) {
       installButton->SetLabelText("Restart Required");
       installButton->Enable(false);
+      installButton->SetToolTip({});
       return;
    }
 
    installButton->SetLabelText(model->installed ? "Installed" : "Install");
    installButton->Enable(!model->installed);
+   installButton->SetToolTip({});
 }
 
 void ModelEntryPanel::SetQueued() {
@@ -113,6 +158,18 @@ void ModelEntryPanel::SetInstalling() {
 void ModelEntryPanel::SetInstalled() {
    UpdateStatus();
 }
+
+void ModelEntryPanel::SetFailed(const wxString& summary) {
+   if (restartRequired && !model->installed) {
+      UpdateStatus();
+      return;
+   }
+
+   installButton->SetLabelText("Retry Install");
+   installButton->Enable(!model->installed);
+   installButton->SetToolTip(summary);
+}
+
 InstallQueueEntryPanel::InstallQueueEntryPanel(wxWindow* parent, ModelEntryPanel* source)
    : wxPanel(parent), modelPanel(source)
 {
@@ -120,20 +177,29 @@ InstallQueueEntryPanel::InstallQueueEntryPanel(wxWindow* parent, ModelEntryPanel
 
    label = new wxStaticText(this, wxID_ANY, source->GetModel()->model_name);
    gauge = new wxGauge(this, wxID_ANY, 100, wxDefaultPosition, wxSize(-1, 16));
+   detailsButton = new wxButton(this, wxID_ANY, "Details");
+   detailsButton->SetInitialSize(detailsButton->GetBestSize());
    gauge->Hide();
+   detailsButton->Disable();
 
    // Add label above
    sizer->Add(label, 1, wxEXPAND | wxLEFT | wxRIGHT | wxTOP, 5);
    // Then add the gauge
    sizer->Add(gauge, 1, wxEXPAND | wxALL, 5);
+   sizer->Add(detailsButton, 0, wxALIGN_CENTER_VERTICAL | wxALL, 5);
 
    SetSizerAndFit(sizer);
+
+   detailsButton->Bind(wxEVT_BUTTON, &InstallQueueEntryPanel::OnViewDetails, this);
 }
 
 void InstallQueueEntryPanel::SetAsInstalling() {
    label->SetLabel(modelPanel->GetModel()->model_name + " (Installing...)");
+   label->SetForegroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT));
    gauge->SetValue(0);
    gauge->Show();
+   detailsButton->Disable();
+   detailsButton->SetToolTip({});
 
    Layout();                        // Update this panel
    if (GetParent()) GetParent()->Layout();  // Update queue sizer
@@ -141,8 +207,25 @@ void InstallQueueEntryPanel::SetAsInstalling() {
 
 void InstallQueueEntryPanel::SetAsQueued() {
    label->SetLabel(modelPanel->GetModel()->model_name + " (Queued)");
+   label->SetForegroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT));
    gauge->Hide();
+    detailsButton->Disable();
+   detailsButton->SetToolTip({});
    Layout();
+}
+
+void InstallQueueEntryPanel::SetAsFailed(const OVModelManager::InstallResult& result) {
+   installResult = result;
+   label->SetLabel(modelPanel->GetModel()->model_name + " (Failed)");
+   label->SetForegroundColour(wxColour(160, 0, 0));
+   gauge->Hide();
+   detailsButton->Enable();
+   detailsButton->SetToolTip(result.summary);
+
+   Layout();
+   if (GetParent()) {
+      GetParent()->Layout();
+   }
 }
 
 void InstallQueueEntryPanel::UpdateProgress(int percent) {
@@ -151,6 +234,12 @@ void InstallQueueEntryPanel::UpdateProgress(int percent) {
 
 ModelEntryPanel* InstallQueueEntryPanel::GetSourcePanel() const {
    return modelPanel;
+}
+
+void InstallQueueEntryPanel::OnViewDetails(wxCommandEvent&) {
+   wxString details = installResult.details.empty() ? installResult.summary : installResult.details;
+   InstallFailureDialog dialog(this, "Install Failure Details", details);
+   dialog.ShowModal();
 }
 
 ModelManagerDialog* ModelManagerDialog::instance = nullptr;
@@ -247,6 +336,10 @@ ModelManagerDialog::ModelManagerDialog(wxWindow* parent)
 }
 
 void ModelManagerDialog::QueueInstall(ModelEntryPanel* panel) {
+   if (auto* existingEntry = FindQueueEntry(panel)) {
+      RemoveQueueEntry(existingEntry);
+   }
+
    panel->SetQueued();
 
    auto* entry = new InstallQueueEntryPanel(this, panel);
@@ -270,22 +363,31 @@ void ModelManagerDialog::BeginInstallFor(ModelEntryPanel* panel) {
       OVModelManager::ProgressCallback callback =
          [this](float perc_complete) {
          wxTheApp->CallAfter([=]() {
-            if (!queuePanels.empty())
-               queuePanels.front()->UpdateProgress(static_cast<int>(perc_complete * 100));
+            if (activeQueueEntry)
+               activeQueueEntry->UpdateProgress(static_cast<int>(perc_complete * 100));
             });
          };
 
-      OVModelManager::instance().install_model(effect, model_name, callback);
+      const auto installResult = OVModelManager::instance().install_model(effect, model_name, callback);
 
       wxTheApp->CallAfter([=]() {
-         activeInstall->SetInstalled();
+         if (installResult) {
+            activeInstall->SetInstalled();
 
-         auto* completedPanel = queuePanels.front();
-         queueSizer->Detach(completedPanel);
-         completedPanel->Destroy();
-         queuePanels.erase(queuePanels.begin());
+            auto* completedPanel = activeQueueEntry;
+            if (completedPanel) {
+               RemoveQueueEntry(completedPanel);
+            }
+         }
+         else {
+            activeInstall->SetFailed(wxString(installResult.summary));
+            if (activeQueueEntry) {
+               activeQueueEntry->SetAsFailed(installResult);
+            }
+         }
 
          activeInstall = nullptr;
+         activeQueueEntry = nullptr;
          StartNextInstall();  // recursively process queue
          });
       }).detach();
@@ -298,9 +400,35 @@ void ModelManagerDialog::StartNextInstall() {
    activeInstall = installQueue.front();
    installQueue.pop();
 
-   auto* queueEntry = queuePanels.front();
-   queueEntry->SetAsInstalling();
-   BeginInstallFor(queueEntry->GetSourcePanel());
+   activeQueueEntry = FindQueueEntry(activeInstall);
+   if (activeQueueEntry) {
+      activeQueueEntry->SetAsInstalling();
+   }
+
+   BeginInstallFor(activeInstall);
+
+   queueSizer->Layout();
+   Layout();
+}
+
+InstallQueueEntryPanel* ModelManagerDialog::FindQueueEntry(ModelEntryPanel* panel) const {
+   for (auto* entry : queuePanels) {
+      if (entry && entry->GetSourcePanel() == panel) {
+         return entry;
+      }
+   }
+
+   return nullptr;
+}
+
+void ModelManagerDialog::RemoveQueueEntry(InstallQueueEntryPanel* entry) {
+   if (!entry) {
+      return;
+   }
+
+   queueSizer->Detach(entry);
+   queuePanels.erase(std::remove(queuePanels.begin(), queuePanels.end(), entry), queuePanels.end());
+   entry->Destroy();
 
    queueSizer->Layout();
    Layout();

--- a/mod-openvino/OVModelManagerUI.cpp
+++ b/mod-openvino/OVModelManagerUI.cpp
@@ -356,33 +356,43 @@ void ModelManagerDialog::QueueInstall(ModelEntryPanel* panel) {
 }
 
 void ModelManagerDialog::BeginInstallFor(ModelEntryPanel* panel, InstallQueueEntryPanel* queueEntry) {
-   std::thread([this, panel, queueEntry]() {
+   const auto queueEntryRaw = queueEntry;
+   const int queueEntryId = queueEntry ? queueEntry->GetId() : wxID_NONE;
+
+   std::thread([this, panel, queueEntryRaw, queueEntryId]() {
 
       auto effect = panel->GetEffect();
       auto model_name = panel->GetModel()->model_name;
 
       OVModelManager::ProgressCallback callback =
-         [this, queueEntry](float perc_complete) {
-         wxTheApp->CallAfter([=]() {
-            if (queueEntry)
-               queueEntry->UpdateProgress(static_cast<int>(perc_complete * 100));
+         [this, queueEntryId](float perc_complete) {
+         wxTheApp->CallAfter([this, queueEntryId, perc_complete]() {
+            auto* liveQueueEntry = FindQueueEntryById(queueEntryId);
+            if (!liveQueueEntry || liveQueueEntry->IsBeingDeleted()) {
+               return;
+            }
+
+            liveQueueEntry->UpdateProgress(static_cast<int>(perc_complete * 100));
             });
          };
 
       const auto installResult = OVModelManager::instance().install_model(effect, model_name, callback);
 
-      wxTheApp->CallAfter([=]() {
+      wxTheApp->CallAfter([this, panel, queueEntryRaw, queueEntryId, installResult]() {
+         auto* liveQueueEntry = FindQueueEntryById(queueEntryId);
+         const bool queueEntryIsValid = liveQueueEntry && !liveQueueEntry->IsBeingDeleted();
+
          if (installResult) {
             panel->SetInstalled();
 
-            if (queueEntry) {
-               RemoveQueueEntry(queueEntry);
+            if (queueEntryIsValid) {
+               RemoveQueueEntry(liveQueueEntry);
             }
          }
          else {
             panel->SetFailed(wxString(installResult.summary));
-            if (queueEntry) {
-               queueEntry->SetAsFailed(installResult);
+            if (queueEntryIsValid) {
+               liveQueueEntry->SetAsFailed(installResult);
             }
          }
 
@@ -390,7 +400,7 @@ void ModelManagerDialog::BeginInstallFor(ModelEntryPanel* panel, InstallQueueEnt
             activeInstall = nullptr;
          }
 
-         if (activeQueueEntry == queueEntry) {
+         if (activeQueueEntry == queueEntryRaw) {
             activeQueueEntry = nullptr;
          }
 
@@ -420,6 +430,20 @@ void ModelManagerDialog::StartNextInstall() {
 InstallQueueEntryPanel* ModelManagerDialog::FindQueueEntry(ModelEntryPanel* panel) const {
    for (auto* entry : queuePanels) {
       if (entry && entry->GetSourcePanel() == panel) {
+         return entry;
+      }
+   }
+
+   return nullptr;
+}
+
+InstallQueueEntryPanel* ModelManagerDialog::FindQueueEntryById(int entryId) const {
+   if (entryId == wxID_NONE) {
+      return nullptr;
+   }
+
+   for (auto* entry : queuePanels) {
+      if (entry && entry->GetId() == entryId) {
          return entry;
       }
    }

--- a/mod-openvino/OVModelManagerUI.h
+++ b/mod-openvino/OVModelManagerUI.h
@@ -35,7 +35,7 @@ private:
    std::vector<InstallQueueEntryPanel*> queuePanels;
    std::queue<ModelEntryPanel*> installQueue;
    ModelEntryPanel* activeInstall = nullptr;
-    InstallQueueEntryPanel* activeQueueEntry = nullptr;
+   InstallQueueEntryPanel* activeQueueEntry = nullptr;
    int installProgress = 0;
 
    wxDECLARE_EVENT_TABLE();

--- a/mod-openvino/OVModelManagerUI.h
+++ b/mod-openvino/OVModelManagerUI.h
@@ -22,7 +22,7 @@ private:
    static ModelManagerDialog* instance;
 
    void StartNextInstall();
-   void BeginInstallFor(ModelEntryPanel* panel);
+   void BeginInstallFor(ModelEntryPanel* panel, InstallQueueEntryPanel* queueEntry);
    InstallQueueEntryPanel* FindQueueEntry(ModelEntryPanel* panel) const;
    void RemoveQueueEntry(InstallQueueEntryPanel* entry);
 

--- a/mod-openvino/OVModelManagerUI.h
+++ b/mod-openvino/OVModelManagerUI.h
@@ -24,6 +24,7 @@ private:
    void StartNextInstall();
    void BeginInstallFor(ModelEntryPanel* panel, InstallQueueEntryPanel* queueEntry);
    InstallQueueEntryPanel* FindQueueEntry(ModelEntryPanel* panel) const;
+   InstallQueueEntryPanel* FindQueueEntryById(int entryId) const;
    void RemoveQueueEntry(InstallQueueEntryPanel* entry);
 
    wxScrolledWindow* scrollPanel;

--- a/mod-openvino/OVModelManagerUI.h
+++ b/mod-openvino/OVModelManagerUI.h
@@ -14,6 +14,7 @@ class ModelEntryPanel;
 class InstallQueueEntryPanel;
 class ModelManagerDialog : public wxDialog {
 public:
+   ~ModelManagerDialog() override;
    static void ShowDialog();
    void QueueInstall(ModelEntryPanel* panel);
 
@@ -23,6 +24,7 @@ private:
 
    void StartNextInstall();
    void BeginInstallFor(ModelEntryPanel* panel, InstallQueueEntryPanel* queueEntry);
+   ModelEntryPanel* FindModelPanelById(int panelId) const;
    InstallQueueEntryPanel* FindQueueEntry(ModelEntryPanel* panel) const;
    InstallQueueEntryPanel* FindQueueEntryById(int entryId) const;
    void RemoveQueueEntry(InstallQueueEntryPanel* entry);

--- a/mod-openvino/OVModelManagerUI.h
+++ b/mod-openvino/OVModelManagerUI.h
@@ -23,6 +23,8 @@ private:
 
    void StartNextInstall();
    void BeginInstallFor(ModelEntryPanel* panel);
+   InstallQueueEntryPanel* FindQueueEntry(ModelEntryPanel* panel) const;
+   void RemoveQueueEntry(InstallQueueEntryPanel* entry);
 
    wxScrolledWindow* scrollPanel;
    wxBoxSizer* modelSizer;
@@ -33,6 +35,7 @@ private:
    std::vector<InstallQueueEntryPanel*> queuePanels;
    std::queue<ModelEntryPanel*> installQueue;
    ModelEntryPanel* activeInstall = nullptr;
+    InstallQueueEntryPanel* activeQueueEntry = nullptr;
    int installProgress = 0;
 
    wxDECLARE_EVENT_TABLE();
@@ -49,6 +52,7 @@ public:
    void SetQueued();
    void SetInstalling();
    void SetInstalled();
+   void SetFailed(const wxString& summary);
 
 private:
    void OnInfo(wxCommandEvent& event);
@@ -68,12 +72,17 @@ public:
 
    void SetAsInstalling();
    void SetAsQueued();
+   void SetAsFailed(const OVModelManager::InstallResult& result);
    void UpdateProgress(int percent);
    ModelEntryPanel* GetSourcePanel() const;
 
 private:
+   void OnViewDetails(wxCommandEvent& event);
+
    ModelEntryPanel* modelPanel;
    wxStaticText* label;
    wxGauge* gauge;
+   wxButton* detailsButton;
+   OVModelManager::InstallResult installResult;
 };
 


### PR DESCRIPTION
The main intent of this PR is to expose the details of any errors that may occur during installation. Previously, errors weren't visible at all (model would simply get removed from the 'Install Queue' without any indication as to why it didn't work).

Now, if there is a failure, the model will stay in the installation queue, get highlighted in red with '(Failed)' next to it. Additionally, the user can click 'Details' to see more verbose reason(s) why the installation failed -- copyable to clipboard, in case they want to share these details to get more help.

<img width="2270" height="1167" alt="image" src="https://github.com/user-attachments/assets/723eb98b-6fff-4da6-9cce-ee140a1fd8d5" />

This PR also removes many of the debug std::cout's that have been present since we started developing the model manager. For ones that are important, they have been switched to use `wxLog` mechanism, so that that they show up in Audacity log.