### PR TITLE
Text-to-Speech Effect (Kokoro)

### DIFF
--- a/mod-openvino/CMakeLists.txt
+++ b/mod-openvino/CMakeLists.txt
@@ -83,6 +83,8 @@ set( SOURCES
       OVReverbRemoval.h
       OVMusicRestoration.cpp
       OVMusicRestoration.h
+      OVTextToSpeechGenAI.cpp
+      OVTextToSpeechGenAI.h
       OVWhisperTranscriptionGenAI.cpp
       OVWhisperTranscriptionGenAI.h
       OpenVINO.cpp

--- a/mod-openvino/OVModelManager.h
+++ b/mod-openvino/OVModelManager.h
@@ -76,6 +76,7 @@ public:
    static const std::string WhisperName() { return "Whisper Transcription"; }
    static const std::string ReverbRemovalName() { return "Reverb Removal"; }
    static const std::string MusicRestorationName() { return "Music Restoration"; }
+   static const std::string TtsName() { return "Text-to-Speech"; }
 
    static OVModelManager& instance() {
       static OVModelManager instance;

--- a/mod-openvino/OVModelManagerPopulation.cpp
+++ b/mod-openvino/OVModelManagerPopulation.cpp
@@ -426,6 +426,95 @@ static std::shared_ptr< OVModelManager::ModelCollection > populate_noise_suppres
 }
 
 
+static std::shared_ptr< OVModelManager::ModelCollection > populate_tts()
+{
+   auto collection = std::make_shared< OVModelManager::ModelCollection >();
+
+   // Kokoro-82M: no public download URL yet; flagged as installed if files are found locally.
+   {
+      std::shared_ptr<OVModelManager::ModelInfo> model = std::make_shared<OVModelManager::ModelInfo>();
+      model->model_name = "Kokoro-82M";
+      model->info = text_to_speech_kokoro_82m;
+      model->baseUrl = ""; // not yet available for download
+      model->relative_path = "text_to_speech/ov_Kokoro-82M";
+      model->fileList =
+      {
+         // Core model files
+         "openvino_model.xml",
+         "openvino_model.bin",
+         "config.json",
+         // Data files
+         "data/gb_gold.json",
+         "data/gb_silver.json",
+         "data/ja_words.txt",
+         "data/us_gold.json",
+         "data/us_silver.json",
+         "data/vi_acronyms.json",
+         "data/vi_symbols.json",
+         "data/vi_teencode.json",
+         // Voice embeddings (af = American Female, am = American Male,
+         //                   bf = British Female, bm = British Male, etc.)
+         "voices/af_alloy.bin",
+         "voices/af_aoede.bin",
+         "voices/af_bella.bin",
+         "voices/af_heart.bin",
+         "voices/af_jessica.bin",
+         "voices/af_kore.bin",
+         "voices/af_nicole.bin",
+         "voices/af_nova.bin",
+         "voices/af_river.bin",
+         "voices/af_sarah.bin",
+         "voices/af_sky.bin",
+         "voices/am_adam.bin",
+         "voices/am_echo.bin",
+         "voices/am_eric.bin",
+         "voices/am_fenrir.bin",
+         "voices/am_liam.bin",
+         "voices/am_michael.bin",
+         "voices/am_onyx.bin",
+         "voices/am_puck.bin",
+         "voices/am_santa.bin",
+         "voices/bf_alice.bin",
+         "voices/bf_emma.bin",
+         "voices/bf_isabella.bin",
+         "voices/bf_lily.bin",
+         "voices/bm_daniel.bin",
+         "voices/bm_fable.bin",
+         "voices/bm_george.bin",
+         "voices/bm_lewis.bin",
+         "voices/ef_dora.bin",
+         "voices/em_alex.bin",
+         "voices/em_santa.bin",
+         "voices/ff_siwis.bin",
+         "voices/hf_alpha.bin",
+         "voices/hf_beta.bin",
+         "voices/hm_omega.bin",
+         "voices/hm_psi.bin",
+         "voices/if_sara.bin",
+         "voices/im_nicola.bin",
+         "voices/jf_alpha.bin",
+         "voices/jf_gongitsune.bin",
+         "voices/jf_nezumi.bin",
+         "voices/jf_tebukuro.bin",
+         "voices/jm_kumo.bin",
+         "voices/pf_dora.bin",
+         "voices/pm_alex.bin",
+         "voices/pm_santa.bin",
+         "voices/zf_xiaobei.bin",
+         "voices/zf_xiaoni.bin",
+         "voices/zf_xiaoxiao.bin",
+         "voices/zf_xiaoyi.bin",
+         "voices/zm_yunjian.bin",
+         "voices/zm_yunxi.bin",
+         "voices/zm_yunxia.bin",
+         "voices/zm_yunyang.bin",
+      };
+      collection->models.emplace_back(model);
+   }
+
+   return collection;
+}
+
 void OVModelManager::_populate_model_collection()
 {
    mModelCollection.insert({ MusicSepName(), populate_music_separation() });
@@ -434,4 +523,5 @@ void OVModelManager::_populate_model_collection()
    mModelCollection.insert({ WhisperName(), populate_whisper() });
    mModelCollection.insert({ ReverbRemovalName(), populate_reverb_removal() });
    mModelCollection.insert({ MusicRestorationName(), populate_music_restoration() });
+   mModelCollection.insert({ TtsName(), populate_tts() });
 }

--- a/mod-openvino/OVModelManagerUI.cpp
+++ b/mod-openvino/OVModelManagerUI.cpp
@@ -290,6 +290,7 @@ ModelManagerDialog::ModelManagerDialog(wxWindow* parent)
       OVModelManager::NoiseSuppressName(),
       OVModelManager::ReverbRemovalName(),
       OVModelManager::SuperResName(),
+      OVModelManager::TtsName(),
       OVModelManager::WhisperName()
       };
 

--- a/mod-openvino/OVTextToSpeechGenAI.cpp
+++ b/mod-openvino/OVTextToSpeechGenAI.cpp
@@ -12,7 +12,6 @@
 
 #include <wx/choice.h>
 #include <wx/dir.h>
-#include <wx/dirdlg.h>
 #include <wx/filename.h>
 #include <wx/intl.h>
 #include <wx/log.h>
@@ -29,6 +28,8 @@
 #include "LabelTrack.h"
 #include "WaveTrack.h"
 #include "effects/EffectEditor.h"
+#include "OVModelManager.h"
+#include "OVModelManagerUI.h"
 
 #include <openvino/openvino.hpp>
 #include "openvino/genai/speech_generation/text2speech_pipeline.hpp"
@@ -86,7 +87,7 @@ ov::Tensor LoadSpeakerEmbeddingTensor(const wxString& speakerEmbeddingPath, cons
 } // namespace
 
 BEGIN_EVENT_TABLE(EffectOVTextToSpeechGenAI, wxEvtHandler)
-   EVT_BUTTON(ID_Type_BrowseModelPath, EffectOVTextToSpeechGenAI::OnBrowseModelPath)
+   EVT_BUTTON(ID_Type_ModelManager, EffectOVTextToSpeechGenAI::OnModelManagerButtonClicked)
 END_EVENT_TABLE()
 
 EffectOVTextToSpeechGenAI::EffectOVTextToSpeechGenAI()
@@ -269,29 +270,26 @@ bool EffectOVTextToSpeechGenAI::ApplyGeneratedBlocksToSelectedTracks(
    return appliedToAnyTrack;
 }
 
-wxString EffectOVTextToSpeechGenAI::ResolveModelPath() const
+std::string EffectOVTextToSpeechGenAI::ResolveModelPath() const
 {
-   if (!mModelPath.empty()) {
-      return mModelPath;
-   }
-
-   const wxString openvinoModelsPath = OpenVINOPluginSettings::GetOrCreateModelDir(true);
-   const wxString speechGenerationDir = wxFileName(openvinoModelsPath, wxT("speech_generation")).GetFullPath();
-
-   if (!wxDirExists(speechGenerationDir)) {
+   const auto collection = OVModelManager::instance().GetModelCollection(OVModelManager::TtsName());
+   if (!collection) {
       return {};
    }
 
-   wxDir speechDir(speechGenerationDir);
-
-   wxString subDirName;
-   bool hasDir = speechDir.GetFirst(&subDirName, wxEmptyString, wxDIR_DIRS);
-   while (hasDir) {
-      const wxString candidate = wxFileName(speechGenerationDir, subDirName).GetFullPath();
-      if (wxDirExists(wxFileName(candidate, wxT("voices")).GetFullPath())) {
-         return candidate;
+   const int idx = mTtsModelSelectionChoice;
+   if (idx >= 0 && idx < static_cast<int>(collection->models.size())) {
+      const auto& model_info = collection->models[idx];
+      if (model_info->installed) {
+         return model_info->installation_path;
       }
-      hasDir = speechDir.GetNext(&subDirName);
+   }
+
+   // Fall back: return installation path of the first installed model.
+   for (const auto& model_info : collection->models) {
+      if (model_info->installed) {
+         return model_info->installation_path;
+      }
    }
 
    return {};
@@ -303,13 +301,13 @@ bool EffectOVTextToSpeechGenAI::GenerateSpeech(const std::string& textToSpeak)
       throw std::runtime_error("Invalid OpenVINO device selection.");
    }
 
-   const wxString resolvedModelPath = ResolveModelPath();
+   const std::string resolvedModelPath = ResolveModelPath();
    if (resolvedModelPath.empty()) {
       throw std::runtime_error(
-         "No text-to-speech model folder is configured. Set Model Folder to an exported OpenVINO GenAI speech model.");
+         "No installed text-to-speech model was found. Use the Model Manager to check available models.");
    }
 
-   const wxString speakerEmbeddingPath = FindSpeakerEmbeddingPath(resolvedModelPath);
+   const wxString speakerEmbeddingPath = FindSpeakerEmbeddingPath(wxString::FromUTF8(resolvedModelPath));
 
    const std::string deviceName = mSupportedDevices[mDeviceSelectionChoice];
 
@@ -321,7 +319,7 @@ bool EffectOVTextToSpeechGenAI::GenerateSpeech(const std::string& textToSpeak)
       properties[ov::cache_dir.name()] = audacity::ToUTF8(wxFileName(cacheFolder).GetFullPath());
    }
 
-   ov::genai::Text2SpeechPipeline pipe(audacity::ToUTF8(resolvedModelPath), deviceName);
+   ov::genai::Text2SpeechPipeline pipe(resolvedModelPath, deviceName);
    ov::Tensor speakerEmbedding = LoadSpeakerEmbeddingTensor(speakerEmbeddingPath, pipe.get_speaker_embedding_shape());
 
    std::cout << "Generating speech for text: " << textToSpeak << std::endl;
@@ -448,13 +446,55 @@ std::unique_ptr<EffectEditor> EffectOVTextToSpeechGenAI::PopulateOrExchange(
 {
    mUIParent = S.GetParent();
 
-   if (mModelPath.empty()) {
-      mModelPath = ResolveModelPath();
+   // Populate installed TTS model choices from the model manager.
+   const auto collection = OVModelManager::instance().GetModelCollection(OVModelManager::TtsName());
+   if (collection) {
+      for (const auto& model_info : collection->models) {
+         if (model_info->installed) {
+            if (std::find(mSupportedTtsModels.begin(), mSupportedTtsModels.end(), model_info->model_name)
+                  == mSupportedTtsModels.end()) {
+               mSupportedTtsModels.push_back(model_info->model_name);
+            }
+         }
+      }
    }
+
+   mGuiTtsModelSelections.clear();
+   for (const auto& m : mSupportedTtsModels) {
+      mGuiTtsModelSelections.push_back({ TranslatableString{ wxString(m), {} } });
+   }
+
+   // Register callback so newly-installed models appear in the choice list live.
+   OVModelManager::InstalledCallback callback =
+      [this](const std::string& model_name) {
+         wxTheApp->CallAfter([=]() {
+            if (std::find(mSupportedTtsModels.begin(), mSupportedTtsModels.end(), model_name)
+                  == mSupportedTtsModels.end()) {
+               mSupportedTtsModels.push_back(model_name);
+               mGuiTtsModelSelections.push_back({ TranslatableString{ wxString(model_name), {} } });
+            }
+            if (mUIParent) {
+               EffectEditor::EnableApply(mUIParent, true);
+               if (mTypeChoiceTtsModelCtrl) {
+                  mTypeChoiceTtsModelCtrl->Append(wxString(model_name));
+                  if (mTypeChoiceTtsModelCtrl->GetCount() == 1) {
+                     mTypeChoiceTtsModelCtrl->SetSelection(0);
+                  }
+               }
+            }
+         });
+      };
+   OVModelManager::instance().register_installed_callback(OVModelManager::TtsName(), callback);
 
    S.AddSpace(0, 5);
    S.StartVerticalLay();
    {
+      S.StartMultiColumn(1, wxLEFT);
+      {
+         S.Id(ID_Type_ModelManager).AddButton(XO("Open Model Manager"));
+      }
+      S.EndMultiColumn();
+
       S.StartMultiColumn(2, wxEXPAND);
       {
          mTypeChoiceDeviceCtrl = S.Id(ID_Type_Device)
@@ -471,20 +511,20 @@ std::unique_ptr<EffectEditor> EffectOVTextToSpeechGenAI::PopulateOrExchange(
       }
       S.EndMultiColumn();
 
+      S.StartMultiColumn(2, wxEXPAND);
+      {
+         mTypeChoiceTtsModelCtrl = S.Id(ID_Type_TtsModel)
+            .MinSize({ -1, -1 })
+            .Validator<wxGenericValidator>(&mTtsModelSelectionChoice)
+            .AddChoice(XXO("TTS Model:"),
+               Msgids(mGuiTtsModelSelections.data(), mGuiTtsModelSelections.size()));
+      }
+      S.EndMultiColumn();
+
       S.StartMultiColumn(1, wxEXPAND);
       {
          mInputTextCtrl = S.Style(wxTE_LEFT | wxTE_MULTILINE)
             .AddTextBox(XXO("Text:"), wxString::FromUTF8(mInputText), 50);
-      }
-      S.EndMultiColumn();
-
-      S.StartMultiColumn(3, wxEXPAND);
-      {
-         mModelPathCtrl = S.Id(ID_Type_ModelPath)
-            .Style(wxTE_LEFT)
-            .AddTextBox(XXO("Model Folder:"), mModelPath, 40);
-
-         S.Id(ID_Type_BrowseModelPath).AddButton(XO("Browse..."));
       }
       S.EndMultiColumn();
    }
@@ -499,8 +539,14 @@ bool EffectOVTextToSpeechGenAI::TransferDataToWindow(const EffectSettings&)
       return false;
    }
 
-   if (mSupportedDevices.empty()) {
-      wxLogInfo("OpenVINO Text-to-Speech has no supported inference devices.");
+   const bool canApply = !mSupportedDevices.empty() && !mSupportedTtsModels.empty();
+   if (!canApply) {
+      if (mSupportedDevices.empty()) {
+         wxLogInfo("OpenVINO Text-to-Speech has no supported inference devices.");
+      }
+      if (mSupportedTtsModels.empty()) {
+         wxLogInfo("OpenVINO Text-to-Speech has no installed models. Use the Model Manager.");
+      }
       EffectEditor::EnableApply(mUIParent, false);
    }
 
@@ -514,19 +560,10 @@ bool EffectOVTextToSpeechGenAI::TransferDataFromWindow(EffectSettings&)
    }
 
    mInputText = audacity::ToUTF8(mInputTextCtrl->GetValue());
-   mModelPath = mModelPathCtrl->GetValue();
    return true;
 }
 
-void EffectOVTextToSpeechGenAI::OnBrowseModelPath(wxCommandEvent&)
+void EffectOVTextToSpeechGenAI::OnModelManagerButtonClicked(wxCommandEvent&)
 {
-   wxDirDialog dialog(
-      mUIParent.get(),
-      XO("Choose an OpenVINO GenAI text-to-speech model directory").Translation(),
-      mModelPath.empty() ? OpenVINOPluginSettings::GetOrCreateModelDir(true) : mModelPath,
-      wxDD_DEFAULT_STYLE | wxDD_DIR_MUST_EXIST);
-
-   if (dialog.ShowModal() == wxID_OK && mModelPathCtrl) {
-      mModelPathCtrl->SetValue(dialog.GetPath());
-   }
+   ShowModelManagerDialog();
 }

--- a/mod-openvino/OVTextToSpeechGenAI.cpp
+++ b/mod-openvino/OVTextToSpeechGenAI.cpp
@@ -203,6 +203,7 @@ ov::Tensor LoadSpeakerEmbeddingTensor(const wxString& speakerEmbeddingPath, cons
 
 BEGIN_EVENT_TABLE(EffectOVTextToSpeechGenAI, wxEvtHandler)
    EVT_BUTTON(ID_Type_ModelManager, EffectOVTextToSpeechGenAI::OnModelManagerButtonClicked)
+   EVT_CHOICE(ID_Type_TextSource, EffectOVTextToSpeechGenAI::OnTextSourceChanged)
    EVT_CHOICE(ID_Type_TtsModel, EffectOVTextToSpeechGenAI::OnTtsModelChanged)
    EVT_CHOICE(ID_Type_Language, EffectOVTextToSpeechGenAI::OnLanguageChanged)
    EVT_CHECKBOX(ID_Type_FilterVoicesByLanguage, EffectOVTextToSpeechGenAI::OnFilterVoicesByLanguageChanged)
@@ -222,11 +223,6 @@ EffectOVTextToSpeechGenAI::EffectOVTextToSpeechGenAI()
 
    for (const auto& d : mSupportedDevices) {
       mGuiDeviceSelections.push_back({ TranslatableString{ wxString(d), {} } });
-   }
-
-   mSupportedTextSources = { "Manual text", "Selected label track" };
-   for (const auto& source : mSupportedTextSources) {
-      mGuiTextSourceSelections.push_back({ TranslatableString{ wxString(source), {} } });
    }
 
    mSupportedLanguages = {
@@ -257,6 +253,21 @@ EffectOVTextToSpeechGenAI::~EffectOVTextToSpeechGenAI() = default;
 ComponentInterfaceSymbol EffectOVTextToSpeechGenAI::GetSymbol() const
 {
    return Symbol;
+}
+
+bool EffectOVTextToSpeechGenAI::HasSelectedLabelTracks() const
+{
+   if (!mTracks) {
+      return false;
+   }
+
+   for (const auto labelTrack : mTracks->Selected<LabelTrack>()) {
+      if (labelTrack != nullptr) {
+         return true;
+      }
+   }
+
+   return false;
 }
 
 TranslatableString EffectOVTextToSpeechGenAI::GetDescription() const
@@ -669,6 +680,23 @@ std::unique_ptr<EffectEditor> EffectOVTextToSpeechGenAI::PopulateOrExchange(
    mTypeChoiceLanguageCtrl = nullptr;
    mInputTextCtrl = nullptr;
 
+   mSupportedTextSources.clear();
+   mGuiTextSourceSelections.clear();
+
+   const bool hasSelectedLabelTracks = HasSelectedLabelTracks();
+   mSupportedTextSources.push_back("Manual text");
+   if (hasSelectedLabelTracks) {
+      mSupportedTextSources.push_back("Selected label track");
+      mTextSourceSelectionChoice = static_cast<int>(TextSource::SelectedLabelTrack);
+   }
+   else {
+      mTextSourceSelectionChoice = static_cast<int>(TextSource::ManualText);
+   }
+
+   for (const auto& source : mSupportedTextSources) {
+      mGuiTextSourceSelections.push_back({ TranslatableString{ wxString(source), {} } });
+   }
+
    mUIParent = S.GetParent();
 
    // Populate installed TTS model choices from the model manager.
@@ -734,12 +762,6 @@ std::unique_ptr<EffectEditor> EffectOVTextToSpeechGenAI::PopulateOrExchange(
             .Validator<wxGenericValidator>(&mDeviceSelectionChoice)
             .AddChoice(XXO("OpenVINO Inference Device:"),
                Msgids(mGuiDeviceSelections.data(), mGuiDeviceSelections.size()));
-
-         mTypeChoiceTextSourceCtrl = S.Id(ID_Type_TextSource)
-            .MinSize({ -1, -1 })
-            .Validator<wxGenericValidator>(&mTextSourceSelectionChoice)
-            .AddChoice(XXO("Text Source:"),
-               Msgids(mGuiTextSourceSelections.data(), mGuiTextSourceSelections.size()));
       }
       S.EndMultiColumn();
 
@@ -772,6 +794,18 @@ std::unique_ptr<EffectEditor> EffectOVTextToSpeechGenAI::PopulateOrExchange(
       }
       S.EndMultiColumn();
 
+      S.StartMultiColumn(2, wxEXPAND);
+      {
+         mTypeChoiceTextSourceCtrl = S.Id(ID_Type_TextSource)
+            .MinSize({ -1, -1 })
+            .Validator<wxGenericValidator>(&mTextSourceSelectionChoice)
+            .AddChoice(XXO("Text Source:"),
+               Msgids(mGuiTextSourceSelections.data(), mGuiTextSourceSelections.size()));
+
+         S.AddVariableText(XO(""));
+      }
+      S.EndMultiColumn();
+
       S.AddVariableText(XO("Text:"));
       mInputTextCtrl = S.Name(XO("Text"))
          .Style(wxTE_MULTILINE)
@@ -788,6 +822,8 @@ bool EffectOVTextToSpeechGenAI::TransferDataToWindow(const EffectSettings&)
    if (!mUIParent || !mUIParent->TransferDataToWindow()) {
       return false;
    }
+
+   UpdateInputTextEnabledState();
 
    const bool canApply = !mSupportedDevices.empty() && !mSupportedTtsModels.empty() && !mVisibleVoices.empty();
    if (!canApply) {
@@ -816,9 +852,26 @@ bool EffectOVTextToSpeechGenAI::TransferDataFromWindow(EffectSettings&)
    return true;
 }
 
+void EffectOVTextToSpeechGenAI::UpdateInputTextEnabledState()
+{
+   if (!mInputTextCtrl) {
+      return;
+   }
+
+   const bool manualTextSelected =
+      static_cast<TextSource>(mTextSourceSelectionChoice) == TextSource::ManualText;
+   mInputTextCtrl->Enable(manualTextSelected);
+}
+
 void EffectOVTextToSpeechGenAI::OnModelManagerButtonClicked(wxCommandEvent&)
 {
    ShowModelManagerDialog();
+}
+
+void EffectOVTextToSpeechGenAI::OnTextSourceChanged(wxCommandEvent& evt)
+{
+   mTextSourceSelectionChoice = evt.GetSelection();
+   UpdateInputTextEnabledState();
 }
 
 void EffectOVTextToSpeechGenAI::OnTtsModelChanged(wxCommandEvent& evt)

--- a/mod-openvino/OVTextToSpeechGenAI.cpp
+++ b/mod-openvino/OVTextToSpeechGenAI.cpp
@@ -375,43 +375,7 @@ bool EffectOVTextToSpeechGenAI::ApplyGeneratedBlocksToSelectedTracks(
    bool appliedToAnyTrack = false;
 
    for (auto pOutWaveTrack : outputs.Get().Selected<WaveTrack>()) {
-      double latestPlacedEnd = std::numeric_limits<double>::lowest();
-
-      for (const auto& block : generatedBlocks) {
-         if (block.speech.empty() || block.sampleRate == 0) {
-            continue;
-         }
-
-         double placementStart = block.preferredStartTime;
-         if (placementStart < latestPlacedEnd) {
-            placementStart = latestPlacedEnd;
-         }
-
-         auto generatedClip = pOutWaveTrack->EmptyCopy();
-         generatedClip->SetRate(block.sampleRate);
-         generatedClip->Append(
-            0,
-            reinterpret_cast<constSamplePtr>(block.speech.data()),
-            floatSample,
-            block.speech.size(),
-            1,
-            widestSampleFormat);
-         generatedClip->Flush();
-
-         constexpr auto preserve = true;
-         constexpr auto merge = true;
-         pOutWaveTrack->ClearAndPaste(
-            placementStart,
-            placementStart,
-            *generatedClip,
-            preserve,
-            merge,
-            nullptr);
-
-         const double blockDuration = static_cast<double>(block.speech.size()) / static_cast<double>(block.sampleRate);
-         latestPlacedEnd = placementStart + blockDuration;
-         appliedToAnyTrack = true;
-      }
+      appliedToAnyTrack = ApplyGeneratedBlocksToTrack(*pOutWaveTrack, generatedBlocks) || appliedToAnyTrack;
    }
 
    if (appliedToAnyTrack) {
@@ -419,6 +383,120 @@ bool EffectOVTextToSpeechGenAI::ApplyGeneratedBlocksToSelectedTracks(
    }
 
    return appliedToAnyTrack;
+}
+
+bool EffectOVTextToSpeechGenAI::ApplyGeneratedBlocksToTrack(
+   WaveTrack& destinationTrack,
+   const std::vector<GeneratedSpeechBlock>& generatedBlocks)
+{
+   double latestPlacedEnd = std::numeric_limits<double>::lowest();
+   bool appliedToTrack = false;
+
+   for (const auto& block : generatedBlocks) {
+      if (block.speech.empty() || block.sampleRate == 0) {
+         continue;
+      }
+
+      double placementStart = block.preferredStartTime;
+      if (placementStart < latestPlacedEnd) {
+         placementStart = latestPlacedEnd;
+      }
+
+      auto generatedClip = destinationTrack.EmptyCopy();
+      generatedClip->SetRate(block.sampleRate);
+      generatedClip->Append(
+         0,
+         reinterpret_cast<constSamplePtr>(block.speech.data()),
+         floatSample,
+         block.speech.size(),
+         1,
+         widestSampleFormat);
+      generatedClip->Flush();
+
+      constexpr auto preserve = true;
+      constexpr auto merge = true;
+      destinationTrack.ClearAndPaste(
+         placementStart,
+         placementStart,
+         *generatedClip,
+         preserve,
+         merge,
+         nullptr);
+
+      const double blockDuration = static_cast<double>(block.speech.size()) / static_cast<double>(block.sampleRate);
+      latestPlacedEnd = placementStart + blockDuration;
+      appliedToTrack = true;
+   }
+
+   return appliedToTrack;
+}
+
+bool EffectOVTextToSpeechGenAI::ApplyGeneratedBlocksToNewTrack(
+   const std::vector<GeneratedSpeechBlock>& generatedBlocks)
+{
+   if (generatedBlocks.empty() || !mTracks || !mFactory) {
+      return false;
+   }
+
+   EffectOutputTracks outputs { *mTracks, EffectTypeNone, std::nullopt, false };
+
+   auto newOutputTrack = mFactory->Create(floatSample, mProjectRate);
+   newOutputTrack->SetName(mTracks->MakeUniqueTrackName(WaveTrack::GetDefaultAudioTrackNamePreference()));
+   newOutputTrack->SetSelected(true);
+
+   bool appliedToTrack = false;
+   double basePlacementStart = 0.0;
+   double latestPlacedEndAbsolute = std::numeric_limits<double>::lowest();
+   double latestPlacedEndRelative = 0.0;
+
+   for (const auto& block : generatedBlocks) {
+      if (block.speech.empty() || block.sampleRate == 0) {
+         continue;
+      }
+
+      double placementStart = block.preferredStartTime;
+      if (placementStart < latestPlacedEndAbsolute) {
+         placementStart = latestPlacedEndAbsolute;
+      }
+
+      if (!appliedToTrack) {
+         newOutputTrack->SetRate(block.sampleRate);
+         basePlacementStart = placementStart;
+      }
+      else {
+         const double relativeStart = placementStart - basePlacementStart;
+         const double silenceDuration = relativeStart - latestPlacedEndRelative;
+         if (silenceDuration > 0.0) {
+            newOutputTrack->InsertSilence(latestPlacedEndRelative, silenceDuration);
+         }
+      }
+
+      newOutputTrack->Append(
+         0,
+         reinterpret_cast<constSamplePtr>(block.speech.data()),
+         floatSample,
+         block.speech.size(),
+         1,
+         widestSampleFormat);
+      // Materialize the appended block before the next timeline edit,
+      // otherwise later InsertSilence operations can act on stale clip state.
+      newOutputTrack->Flush();
+
+      const double blockDuration = static_cast<double>(block.speech.size()) / static_cast<double>(block.sampleRate);
+      latestPlacedEndAbsolute = placementStart + blockDuration;
+      latestPlacedEndRelative = latestPlacedEndAbsolute - basePlacementStart;
+      appliedToTrack = true;
+   }
+
+   if (!appliedToTrack) {
+      return false;
+   }
+
+   newOutputTrack->MoveTo(basePlacementStart);
+
+   outputs.AddToOutputTracks(newOutputTrack);
+   outputs.Commit();
+   return true;
 }
 
 std::string EffectOVTextToSpeechGenAI::ResolveModelPath() const
@@ -603,10 +681,14 @@ bool EffectOVTextToSpeechGenAI::Process(EffectInstance& instance, EffectSettings
                });
          }
 
-         if (!ApplyGeneratedBlocksToSelectedTracks(generatedBlocks)) {
+         const bool applied = mGenerateIntoNewTrack
+            ? ApplyGeneratedBlocksToNewTrack(generatedBlocks)
+            : ApplyGeneratedBlocksToSelectedTracks(generatedBlocks);
+
+         if (!applied) {
             EffectUIServices::DoMessageBox(
                *this,
-               XO("Text-to-Speech needs at least one selected audio track to place generated snippets."),
+               XO("Text-to-Speech needs at least one selected audio track to place generated snippets, or enable Generate into new track."),
                wxICON_STOP,
                XO("Error"));
             return false;
@@ -678,6 +760,7 @@ std::unique_ptr<EffectEditor> EffectOVTextToSpeechGenAI::PopulateOrExchange(
    mTypeChoiceTtsModelCtrl = nullptr;
    mTypeChoiceVoiceCtrl = nullptr;
    mTypeChoiceLanguageCtrl = nullptr;
+   mGenerateIntoNewTrackCtrl = nullptr;
    mInputTextCtrl = nullptr;
 
    mSupportedTextSources.clear();
@@ -802,7 +885,9 @@ std::unique_ptr<EffectEditor> EffectOVTextToSpeechGenAI::PopulateOrExchange(
             .AddChoice(XXO("Text Source:"),
                Msgids(mGuiTextSourceSelections.data(), mGuiTextSourceSelections.size()));
 
-         S.AddVariableText(XO(""));
+         mGenerateIntoNewTrackCtrl = S.Id(ID_Type_GenerateIntoNewTrack)
+            .Validator<wxGenericValidator>(&mGenerateIntoNewTrack)
+            .AddCheckBox(XXO("Generate into new track"), mGenerateIntoNewTrack);
       }
       S.EndMultiColumn();
 
@@ -823,7 +908,7 @@ bool EffectOVTextToSpeechGenAI::TransferDataToWindow(const EffectSettings&)
       return false;
    }
 
-   UpdateInputTextEnabledState();
+   UpdateTextSourceDependentControlStates();
 
    const bool canApply = !mSupportedDevices.empty() && !mSupportedTtsModels.empty() && !mVisibleVoices.empty();
    if (!canApply) {
@@ -863,6 +948,19 @@ void EffectOVTextToSpeechGenAI::UpdateInputTextEnabledState()
    mInputTextCtrl->Enable(manualTextSelected);
 }
 
+void EffectOVTextToSpeechGenAI::UpdateTextSourceDependentControlStates()
+{
+   UpdateInputTextEnabledState();
+
+   if (!mGenerateIntoNewTrackCtrl) {
+      return;
+   }
+
+   const bool labelTrackSelected =
+      static_cast<TextSource>(mTextSourceSelectionChoice) == TextSource::SelectedLabelTrack;
+   mGenerateIntoNewTrackCtrl->Enable(labelTrackSelected);
+}
+
 void EffectOVTextToSpeechGenAI::OnModelManagerButtonClicked(wxCommandEvent&)
 {
    ShowModelManagerDialog();
@@ -871,7 +969,7 @@ void EffectOVTextToSpeechGenAI::OnModelManagerButtonClicked(wxCommandEvent&)
 void EffectOVTextToSpeechGenAI::OnTextSourceChanged(wxCommandEvent& evt)
 {
    mTextSourceSelectionChoice = evt.GetSelection();
-   UpdateInputTextEnabledState();
+   UpdateTextSourceDependentControlStates();
 }
 
 void EffectOVTextToSpeechGenAI::OnTtsModelChanged(wxCommandEvent& evt)

--- a/mod-openvino/OVTextToSpeechGenAI.cpp
+++ b/mod-openvino/OVTextToSpeechGenAI.cpp
@@ -40,11 +40,53 @@ const ComponentInterfaceSymbol EffectOVTextToSpeechGenAI::Symbol
 namespace { BuiltinEffectsModule::Registration<EffectOVTextToSpeechGenAI> reg; }
 
 namespace {
-wxString FindSpeakerEmbeddingPath(const wxString& modelPath)
+std::string NormalizeKokoroLanguage(std::string language)
 {
-   const wxString voicesPath = wxFileName(modelPath, wxT("voices")).GetFullPath();
+   if (language == "es-es") {
+      return "es";
+   }
+   if (language == "hi-in") {
+      return "hi";
+   }
+   if (language == "it-it") {
+      return "it";
+   }
+   return language;
+}
+
+std::vector<std::string> ScanVoicesInModelPath(const std::string& modelPath)
+{
+   const wxString voicesPath = wxFileName(wxString::FromUTF8(modelPath), wxT("voices")).GetFullPath();
+   if (!wxDirExists(voicesPath)) {
+      return {};
+   }
+
+   wxDir voicesDir(voicesPath);
+   wxString fileName;
+   std::vector<std::string> voices;
+   bool hasFile = voicesDir.GetFirst(&fileName, wxT("*.bin"), wxDIR_FILES);
+   while (hasFile) {
+      const wxFileName voiceFile(fileName);
+      voices.push_back(audacity::ToUTF8(voiceFile.GetName()));
+      hasFile = voicesDir.GetNext(&fileName);
+   }
+
+   std::sort(voices.begin(), voices.end());
+   return voices;
+}
+
+wxString FindSpeakerEmbeddingPath(const std::string& modelPath, const std::string& selectedVoice)
+{
+   const wxString voicesPath = wxFileName(wxString::FromUTF8(modelPath), wxT("voices")).GetFullPath();
    if (!wxDirExists(voicesPath)) {
       throw std::runtime_error("The selected model folder does not contain a 'voices' directory.");
+   }
+
+   if (!selectedVoice.empty()) {
+      const wxString requestedVoice = wxFileName(voicesPath, wxString::FromUTF8(selectedVoice + ".bin")).GetFullPath();
+      if (wxFileExists(requestedVoice)) {
+         return requestedVoice;
+      }
    }
 
    const wxString preferredVoice = wxFileName(voicesPath, wxT("af_heart.bin")).GetFullPath();
@@ -88,6 +130,7 @@ ov::Tensor LoadSpeakerEmbeddingTensor(const wxString& speakerEmbeddingPath, cons
 
 BEGIN_EVENT_TABLE(EffectOVTextToSpeechGenAI, wxEvtHandler)
    EVT_BUTTON(ID_Type_ModelManager, EffectOVTextToSpeechGenAI::OnModelManagerButtonClicked)
+   EVT_CHOICE(ID_Type_TtsModel, EffectOVTextToSpeechGenAI::OnTtsModelChanged)
 END_EVENT_TABLE()
 
 EffectOVTextToSpeechGenAI::EffectOVTextToSpeechGenAI()
@@ -109,6 +152,19 @@ EffectOVTextToSpeechGenAI::EffectOVTextToSpeechGenAI()
    mSupportedTextSources = { "Manual text", "Selected label track" };
    for (const auto& source : mSupportedTextSources) {
       mGuiTextSourceSelections.push_back({ TranslatableString{ wxString(source), {} } });
+   }
+
+   mSupportedLanguages = {
+      "en-us",
+      "en-gb",
+      "es",
+      "fr-fr",
+      "hi",
+      "it",
+      "pt-br"
+   };
+   for (const auto& language : mSupportedLanguages) {
+      mGuiLanguageSelections.push_back({ TranslatableString{ wxString(language), {} } });
    }
 }
 
@@ -277,11 +333,12 @@ std::string EffectOVTextToSpeechGenAI::ResolveModelPath() const
       return {};
    }
 
-   const int idx = mTtsModelSelectionChoice;
-   if (idx >= 0 && idx < static_cast<int>(collection->models.size())) {
-      const auto& model_info = collection->models[idx];
-      if (model_info->installed) {
-         return model_info->installation_path;
+   if (mTtsModelSelectionChoice >= 0 && mTtsModelSelectionChoice < static_cast<int>(mSupportedTtsModels.size())) {
+      const std::string selectedModelName = mSupportedTtsModels[mTtsModelSelectionChoice];
+      for (const auto& model_info : collection->models) {
+         if (model_info->installed && model_info->model_name == selectedModelName) {
+            return model_info->installation_path;
+         }
       }
    }
 
@@ -293,6 +350,46 @@ std::string EffectOVTextToSpeechGenAI::ResolveModelPath() const
    }
 
    return {};
+}
+
+void EffectOVTextToSpeechGenAI::RefreshVoicesForCurrentModel()
+{
+   mSupportedVoices.clear();
+   mGuiVoiceSelections.clear();
+
+   const std::string modelPath = ResolveModelPath();
+   if (!modelPath.empty()) {
+      mSupportedVoices = ScanVoicesInModelPath(modelPath);
+   }
+
+   for (const auto& voice : mSupportedVoices) {
+      mGuiVoiceSelections.push_back({ TranslatableString{ wxString(voice), {} } });
+   }
+
+   auto requestedSelection = mVoiceSelectionChoice;
+   const auto preferredVoice = std::find(mSupportedVoices.begin(), mSupportedVoices.end(), "af_heart");
+   if (preferredVoice != mSupportedVoices.end()) {
+      requestedSelection = static_cast<int>(std::distance(mSupportedVoices.begin(), preferredVoice));
+   }
+
+   if (mSupportedVoices.empty()) {
+      mVoiceSelectionChoice = 0;
+      if (mTypeChoiceVoiceCtrl) {
+         mTypeChoiceVoiceCtrl->Clear();
+      }
+      return;
+   }
+
+   requestedSelection = std::clamp(requestedSelection, 0, static_cast<int>(mSupportedVoices.size()) - 1);
+   mVoiceSelectionChoice = requestedSelection;
+
+   if (mTypeChoiceVoiceCtrl) {
+      mTypeChoiceVoiceCtrl->Clear();
+      for (const auto& voice : mSupportedVoices) {
+         mTypeChoiceVoiceCtrl->Append(wxString(voice));
+      }
+      mTypeChoiceVoiceCtrl->SetSelection(mVoiceSelectionChoice);
+   }
 }
 
 bool EffectOVTextToSpeechGenAI::GenerateSpeech(const std::string& textToSpeak)
@@ -307,12 +404,21 @@ bool EffectOVTextToSpeechGenAI::GenerateSpeech(const std::string& textToSpeak)
          "No installed text-to-speech model was found. Use the Model Manager to check available models.");
    }
 
-   const wxString speakerEmbeddingPath = FindSpeakerEmbeddingPath(wxString::FromUTF8(resolvedModelPath));
+   std::string selectedVoice;
+   if (mVoiceSelectionChoice >= 0 && mVoiceSelectionChoice < static_cast<int>(mSupportedVoices.size())) {
+      selectedVoice = mSupportedVoices[mVoiceSelectionChoice];
+   }
+   const wxString speakerEmbeddingPath = FindSpeakerEmbeddingPath(resolvedModelPath, selectedVoice);
 
    const std::string deviceName = mSupportedDevices[mDeviceSelectionChoice];
 
    ov::AnyMap properties;
-   properties["language"] = std::string("en-us");
+   std::string selectedLanguage = "en-us";
+   if (mLanguageSelectionChoice >= 0 && mLanguageSelectionChoice < static_cast<int>(mSupportedLanguages.size())) {
+      selectedLanguage = mSupportedLanguages[mLanguageSelectionChoice];
+   }
+   selectedLanguage = NormalizeKokoroLanguage(selectedLanguage);
+   properties["language"] = selectedLanguage;
 
    if (OpenVINOPluginSettings::ReadEnableCache() && deviceName != "CPU") {
       const auto cacheFolder = FileNames::MkDir(wxFileName(OpenVINOPluginSettings::GetOrCreateCompiledModelCacheDir()).GetFullPath());
@@ -444,6 +550,15 @@ bool EffectOVTextToSpeechGenAI::GenerateTrack(const EffectSettings&, WaveTrack& 
 std::unique_ptr<EffectEditor> EffectOVTextToSpeechGenAI::PopulateOrExchange(
    ShuttleGui& S, EffectInstance&, EffectSettingsAccess&, const EffectOutputs*)
 {
+   // Controls are re-created on each dialog open; reset cached pointers first
+   // so stale pointers from a previous dialog instance are never reused.
+   mTypeChoiceDeviceCtrl = nullptr;
+   mTypeChoiceTextSourceCtrl = nullptr;
+   mTypeChoiceTtsModelCtrl = nullptr;
+   mTypeChoiceVoiceCtrl = nullptr;
+   mTypeChoiceLanguageCtrl = nullptr;
+   mInputTextCtrl = nullptr;
+
    mUIParent = S.GetParent();
 
    // Populate installed TTS model choices from the model manager.
@@ -479,12 +594,19 @@ std::unique_ptr<EffectEditor> EffectOVTextToSpeechGenAI::PopulateOrExchange(
                   mTypeChoiceTtsModelCtrl->Append(wxString(model_name));
                   if (mTypeChoiceTtsModelCtrl->GetCount() == 1) {
                      mTypeChoiceTtsModelCtrl->SetSelection(0);
+                     mTtsModelSelectionChoice = 0;
                   }
                }
+               RefreshVoicesForCurrentModel();
             }
          });
       };
    OVModelManager::instance().register_installed_callback(OVModelManager::TtsName(), callback);
+
+   if (mTtsModelSelectionChoice < 0 && !mSupportedTtsModels.empty()) {
+      mTtsModelSelectionChoice = 0;
+   }
+   RefreshVoicesForCurrentModel();
 
    S.AddSpace(0, 5);
    S.StartVerticalLay();
@@ -518,6 +640,22 @@ std::unique_ptr<EffectEditor> EffectOVTextToSpeechGenAI::PopulateOrExchange(
             .Validator<wxGenericValidator>(&mTtsModelSelectionChoice)
             .AddChoice(XXO("TTS Model:"),
                Msgids(mGuiTtsModelSelections.data(), mGuiTtsModelSelections.size()));
+
+         mTypeChoiceVoiceCtrl = S.Id(ID_Type_Voice)
+            .MinSize({ -1, -1 })
+            .Validator<wxGenericValidator>(&mVoiceSelectionChoice)
+            .AddChoice(XXO("Voice:"),
+               Msgids(mGuiVoiceSelections.data(), mGuiVoiceSelections.size()));
+      }
+      S.EndMultiColumn();
+
+      S.StartMultiColumn(2, wxEXPAND);
+      {
+         mTypeChoiceLanguageCtrl = S.Id(ID_Type_Language)
+            .MinSize({ -1, -1 })
+            .Validator<wxGenericValidator>(&mLanguageSelectionChoice)
+            .AddChoice(XXO("Language:"),
+               Msgids(mGuiLanguageSelections.data(), mGuiLanguageSelections.size()));
       }
       S.EndMultiColumn();
 
@@ -539,13 +677,16 @@ bool EffectOVTextToSpeechGenAI::TransferDataToWindow(const EffectSettings&)
       return false;
    }
 
-   const bool canApply = !mSupportedDevices.empty() && !mSupportedTtsModels.empty();
+   const bool canApply = !mSupportedDevices.empty() && !mSupportedTtsModels.empty() && !mSupportedVoices.empty();
    if (!canApply) {
       if (mSupportedDevices.empty()) {
          wxLogInfo("OpenVINO Text-to-Speech has no supported inference devices.");
       }
       if (mSupportedTtsModels.empty()) {
          wxLogInfo("OpenVINO Text-to-Speech has no installed models. Use the Model Manager.");
+      }
+      if (mSupportedTtsModels.empty() == false && mSupportedVoices.empty()) {
+         wxLogInfo("OpenVINO Text-to-Speech could not find voice embeddings for the selected model.");
       }
       EffectEditor::EnableApply(mUIParent, false);
    }
@@ -566,4 +707,9 @@ bool EffectOVTextToSpeechGenAI::TransferDataFromWindow(EffectSettings&)
 void EffectOVTextToSpeechGenAI::OnModelManagerButtonClicked(wxCommandEvent&)
 {
    ShowModelManagerDialog();
+}
+
+void EffectOVTextToSpeechGenAI::OnTtsModelChanged(wxCommandEvent&)
+{
+   RefreshVoicesForCurrentModel();
 }

--- a/mod-openvino/OVTextToSpeechGenAI.cpp
+++ b/mod-openvino/OVTextToSpeechGenAI.cpp
@@ -77,6 +77,56 @@ std::string FormatVoiceDisplayLabel(const std::string& voiceName)
    return voiceName + " [" + language + ", " + gender + "]";
 }
 
+bool TryGetVoiceLanguagePrefix(const std::string& voiceName, char& prefix)
+{
+   if (voiceName.size() < 4 || voiceName[2] != '_') {
+      return false;
+   }
+
+   const char candidate = voiceName[0];
+   switch (candidate) {
+   case 'a':
+   case 'b':
+   case 'e':
+   case 'f':
+   case 'h':
+   case 'i':
+   case 'j':
+   case 'p':
+   case 'z':
+      prefix = candidate;
+      return true;
+   default:
+      return false;
+   }
+}
+
+char LanguageCodeToVoicePrefix(const std::string& languageCode)
+{
+   if (languageCode == "en-us") {
+      return 'a';
+   }
+   if (languageCode == "en-gb") {
+      return 'b';
+   }
+   if (languageCode == "es") {
+      return 'e';
+   }
+   if (languageCode == "fr-fr") {
+      return 'f';
+   }
+   if (languageCode == "hi") {
+      return 'h';
+   }
+   if (languageCode == "it") {
+      return 'i';
+   }
+   if (languageCode == "pt-br") {
+      return 'p';
+   }
+   return '\0';
+}
+
 std::vector<std::string> ScanVoicesInModelPath(const std::string& modelPath)
 {
    const wxString voicesPath = wxFileName(wxString::FromUTF8(modelPath), wxT("voices")).GetFullPath();
@@ -154,6 +204,8 @@ ov::Tensor LoadSpeakerEmbeddingTensor(const wxString& speakerEmbeddingPath, cons
 BEGIN_EVENT_TABLE(EffectOVTextToSpeechGenAI, wxEvtHandler)
    EVT_BUTTON(ID_Type_ModelManager, EffectOVTextToSpeechGenAI::OnModelManagerButtonClicked)
    EVT_CHOICE(ID_Type_TtsModel, EffectOVTextToSpeechGenAI::OnTtsModelChanged)
+   EVT_CHOICE(ID_Type_Language, EffectOVTextToSpeechGenAI::OnLanguageChanged)
+   EVT_CHECKBOX(ID_Type_FilterVoicesByLanguage, EffectOVTextToSpeechGenAI::OnFilterVoicesByLanguageChanged)
 END_EVENT_TABLE()
 
 EffectOVTextToSpeechGenAI::EffectOVTextToSpeechGenAI()
@@ -386,7 +438,13 @@ std::string EffectOVTextToSpeechGenAI::ResolveModelPath() const
 
 void EffectOVTextToSpeechGenAI::RefreshVoicesForCurrentModel()
 {
+   std::string previouslySelectedVoice;
+   if (mVoiceSelectionChoice >= 0 && mVoiceSelectionChoice < static_cast<int>(mVisibleVoices.size())) {
+      previouslySelectedVoice = mVisibleVoices[mVoiceSelectionChoice];
+   }
+
    mSupportedVoices.clear();
+   mVisibleVoices.clear();
    mGuiVoiceSelections.clear();
 
    const std::string modelPath = ResolveModelPath();
@@ -394,17 +452,38 @@ void EffectOVTextToSpeechGenAI::RefreshVoicesForCurrentModel()
       mSupportedVoices = ScanVoicesInModelPath(modelPath);
    }
 
+   char desiredPrefix = '\0';
+   if (mLanguageSelectionChoice >= 0 && mLanguageSelectionChoice < static_cast<int>(mSupportedLanguageCodes.size())) {
+      desiredPrefix = LanguageCodeToVoicePrefix(mSupportedLanguageCodes[mLanguageSelectionChoice]);
+   }
+
    for (const auto& voice : mSupportedVoices) {
+      char voicePrefix = '\0';
+      const bool hasKnownPrefix = TryGetVoiceLanguagePrefix(voice, voicePrefix);
+      if (!mFilterVoicesByLanguage || desiredPrefix == '\0' || !hasKnownPrefix || voicePrefix == desiredPrefix) {
+         mVisibleVoices.push_back(voice);
+      }
+   }
+
+   for (const auto& voice : mVisibleVoices) {
       mGuiVoiceSelections.push_back({ TranslatableString{ wxString(FormatVoiceDisplayLabel(voice)), {} } });
    }
 
-   auto requestedSelection = mVoiceSelectionChoice;
-   const auto preferredVoice = std::find(mSupportedVoices.begin(), mSupportedVoices.end(), "af_heart");
-   if (preferredVoice != mSupportedVoices.end()) {
-      requestedSelection = static_cast<int>(std::distance(mSupportedVoices.begin(), preferredVoice));
+   int requestedSelection = 0;
+   if (!previouslySelectedVoice.empty()) {
+      const auto selectedIter = std::find(mVisibleVoices.begin(), mVisibleVoices.end(), previouslySelectedVoice);
+      if (selectedIter != mVisibleVoices.end()) {
+         requestedSelection = static_cast<int>(std::distance(mVisibleVoices.begin(), selectedIter));
+      }
+   }
+   else {
+      const auto preferredVoice = std::find(mVisibleVoices.begin(), mVisibleVoices.end(), "af_heart");
+      if (preferredVoice != mVisibleVoices.end()) {
+         requestedSelection = static_cast<int>(std::distance(mVisibleVoices.begin(), preferredVoice));
+      }
    }
 
-   if (mSupportedVoices.empty()) {
+   if (mVisibleVoices.empty()) {
       mVoiceSelectionChoice = 0;
       if (mTypeChoiceVoiceCtrl) {
          mTypeChoiceVoiceCtrl->Clear();
@@ -412,12 +491,12 @@ void EffectOVTextToSpeechGenAI::RefreshVoicesForCurrentModel()
       return;
    }
 
-   requestedSelection = std::clamp(requestedSelection, 0, static_cast<int>(mSupportedVoices.size()) - 1);
+   requestedSelection = std::clamp(requestedSelection, 0, static_cast<int>(mVisibleVoices.size()) - 1);
    mVoiceSelectionChoice = requestedSelection;
 
    if (mTypeChoiceVoiceCtrl) {
       mTypeChoiceVoiceCtrl->Clear();
-      for (const auto& voice : mSupportedVoices) {
+      for (const auto& voice : mVisibleVoices) {
          mTypeChoiceVoiceCtrl->Append(wxString(FormatVoiceDisplayLabel(voice)));
       }
       mTypeChoiceVoiceCtrl->SetSelection(mVoiceSelectionChoice);
@@ -437,8 +516,8 @@ bool EffectOVTextToSpeechGenAI::GenerateSpeech(const std::string& textToSpeak)
    }
 
    std::string selectedVoice;
-   if (mVoiceSelectionChoice >= 0 && mVoiceSelectionChoice < static_cast<int>(mSupportedVoices.size())) {
-      selectedVoice = mSupportedVoices[mVoiceSelectionChoice];
+   if (mVoiceSelectionChoice >= 0 && mVoiceSelectionChoice < static_cast<int>(mVisibleVoices.size())) {
+      selectedVoice = mVisibleVoices[mVoiceSelectionChoice];
    }
    const wxString speakerEmbeddingPath = FindSpeakerEmbeddingPath(resolvedModelPath, selectedVoice);
 
@@ -687,6 +766,9 @@ std::unique_ptr<EffectEditor> EffectOVTextToSpeechGenAI::PopulateOrExchange(
             .Validator<wxGenericValidator>(&mLanguageSelectionChoice)
             .AddChoice(XXO("Language:"),
                Msgids(mGuiLanguageSelections.data(), mGuiLanguageSelections.size()));
+
+         S.Id(ID_Type_FilterVoicesByLanguage)
+            .AddCheckBox(XXO("Filter voices by selected language"), mFilterVoicesByLanguage);
       }
       S.EndMultiColumn();
 
@@ -708,7 +790,7 @@ bool EffectOVTextToSpeechGenAI::TransferDataToWindow(const EffectSettings&)
       return false;
    }
 
-   const bool canApply = !mSupportedDevices.empty() && !mSupportedTtsModels.empty() && !mSupportedVoices.empty();
+   const bool canApply = !mSupportedDevices.empty() && !mSupportedTtsModels.empty() && !mVisibleVoices.empty();
    if (!canApply) {
       if (mSupportedDevices.empty()) {
          wxLogInfo("OpenVINO Text-to-Speech has no supported inference devices.");
@@ -716,7 +798,7 @@ bool EffectOVTextToSpeechGenAI::TransferDataToWindow(const EffectSettings&)
       if (mSupportedTtsModels.empty()) {
          wxLogInfo("OpenVINO Text-to-Speech has no installed models. Use the Model Manager.");
       }
-      if (mSupportedTtsModels.empty() == false && mSupportedVoices.empty()) {
+      if (mSupportedTtsModels.empty() == false && mVisibleVoices.empty()) {
          wxLogInfo("OpenVINO Text-to-Speech could not find voice embeddings for the selected model.");
       }
       EffectEditor::EnableApply(mUIParent, false);
@@ -740,7 +822,22 @@ void EffectOVTextToSpeechGenAI::OnModelManagerButtonClicked(wxCommandEvent&)
    ShowModelManagerDialog();
 }
 
-void EffectOVTextToSpeechGenAI::OnTtsModelChanged(wxCommandEvent&)
+void EffectOVTextToSpeechGenAI::OnTtsModelChanged(wxCommandEvent& evt)
 {
+   mTtsModelSelectionChoice = evt.GetSelection();
+   RefreshVoicesForCurrentModel();
+}
+
+void EffectOVTextToSpeechGenAI::OnLanguageChanged(wxCommandEvent& evt)
+{
+   mLanguageSelectionChoice = evt.GetSelection();
+   if (mFilterVoicesByLanguage) {
+      RefreshVoicesForCurrentModel();
+   }
+}
+
+void EffectOVTextToSpeechGenAI::OnFilterVoicesByLanguageChanged(wxCommandEvent& evt)
+{
+   mFilterVoicesByLanguage = evt.IsChecked();
    RefreshVoicesForCurrentModel();
 }

--- a/mod-openvino/OVTextToSpeechGenAI.cpp
+++ b/mod-openvino/OVTextToSpeechGenAI.cpp
@@ -40,18 +40,41 @@ const ComponentInterfaceSymbol EffectOVTextToSpeechGenAI::Symbol
 namespace { BuiltinEffectsModule::Registration<EffectOVTextToSpeechGenAI> reg; }
 
 namespace {
-std::string NormalizeKokoroLanguage(std::string language)
+std::string FormatVoiceDisplayLabel(const std::string& voiceName)
 {
-   if (language == "es-es") {
-      return "es";
+   // Kokoro voice convention: <language><gender>_<name>
+   // Examples: af_heart, bm_george, pf_dora
+   if (voiceName.size() < 4 || voiceName[2] != '_') {
+      return voiceName;
    }
-   if (language == "hi-in") {
-      return "hi";
+
+   const char languageCode = voiceName[0];
+   const char genderCode = voiceName[1];
+
+   std::string language;
+   switch (languageCode) {
+   case 'a': language = "English (US)"; break;
+   case 'b': language = "English (UK)"; break;
+   case 'e': language = "Spanish"; break;
+   case 'f': language = "French"; break;
+   case 'h': language = "Hindi"; break;
+   case 'i': language = "Italian"; break;
+   case 'j': language = "Japanese"; break;
+   case 'p': language = "Portuguese (Brazil)"; break;
+   case 'z': language = "Chinese"; break;
+   default:
+      return voiceName;
    }
-   if (language == "it-it") {
-      return "it";
+
+   std::string gender;
+   switch (genderCode) {
+   case 'm': gender = "Male"; break;
+   case 'f': gender = "Female"; break;
+   default:
+      return voiceName;
    }
-   return language;
+
+   return voiceName + " [" + language + ", " + gender + "]";
 }
 
 std::vector<std::string> ScanVoicesInModelPath(const std::string& modelPath)
@@ -155,6 +178,15 @@ EffectOVTextToSpeechGenAI::EffectOVTextToSpeechGenAI()
    }
 
    mSupportedLanguages = {
+      "English (US)",
+      "English (UK)",
+      "Spanish",
+      "French",
+      "Hindi",
+      "Italian",
+      "Portuguese (Brazil)"
+   };
+   mSupportedLanguageCodes = {
       "en-us",
       "en-gb",
       "es",
@@ -163,8 +195,8 @@ EffectOVTextToSpeechGenAI::EffectOVTextToSpeechGenAI()
       "it",
       "pt-br"
    };
-   for (const auto& language : mSupportedLanguages) {
-      mGuiLanguageSelections.push_back({ TranslatableString{ wxString(language), {} } });
+   for (const auto& languageLabel : mSupportedLanguages) {
+      mGuiLanguageSelections.push_back({ TranslatableString{ wxString(languageLabel), {} } });
    }
 }
 
@@ -363,7 +395,7 @@ void EffectOVTextToSpeechGenAI::RefreshVoicesForCurrentModel()
    }
 
    for (const auto& voice : mSupportedVoices) {
-      mGuiVoiceSelections.push_back({ TranslatableString{ wxString(voice), {} } });
+      mGuiVoiceSelections.push_back({ TranslatableString{ wxString(FormatVoiceDisplayLabel(voice)), {} } });
    }
 
    auto requestedSelection = mVoiceSelectionChoice;
@@ -386,7 +418,7 @@ void EffectOVTextToSpeechGenAI::RefreshVoicesForCurrentModel()
    if (mTypeChoiceVoiceCtrl) {
       mTypeChoiceVoiceCtrl->Clear();
       for (const auto& voice : mSupportedVoices) {
-         mTypeChoiceVoiceCtrl->Append(wxString(voice));
+         mTypeChoiceVoiceCtrl->Append(wxString(FormatVoiceDisplayLabel(voice)));
       }
       mTypeChoiceVoiceCtrl->SetSelection(mVoiceSelectionChoice);
    }
@@ -413,12 +445,11 @@ bool EffectOVTextToSpeechGenAI::GenerateSpeech(const std::string& textToSpeak)
    const std::string deviceName = mSupportedDevices[mDeviceSelectionChoice];
 
    ov::AnyMap properties;
-   std::string selectedLanguage = "en-us";
-   if (mLanguageSelectionChoice >= 0 && mLanguageSelectionChoice < static_cast<int>(mSupportedLanguages.size())) {
-      selectedLanguage = mSupportedLanguages[mLanguageSelectionChoice];
+   std::string selectedLanguageCode = "en-us";
+   if (mLanguageSelectionChoice >= 0 && mLanguageSelectionChoice < static_cast<int>(mSupportedLanguageCodes.size())) {
+      selectedLanguageCode = mSupportedLanguageCodes[mLanguageSelectionChoice];
    }
-   selectedLanguage = NormalizeKokoroLanguage(selectedLanguage);
-   properties["language"] = selectedLanguage;
+   properties["language"] = selectedLanguageCode;
 
    if (OpenVINOPluginSettings::ReadEnableCache() && deviceName != "CPU") {
       const auto cacheFolder = FileNames::MkDir(wxFileName(OpenVINOPluginSettings::GetOrCreateCompiledModelCacheDir()).GetFullPath());

--- a/mod-openvino/OVTextToSpeechGenAI.cpp
+++ b/mod-openvino/OVTextToSpeechGenAI.cpp
@@ -1,0 +1,532 @@
+// Copyright (C) 2026 Intel Corporation
+// SPDX-License-Identifier: GPL-3.0-only
+
+#include "OVTextToSpeechGenAI.h"
+
+#include <algorithm>
+#include <cmath>
+#include <fstream>
+#include <limits>
+#include <numeric>
+#include <stdexcept>
+
+#include <wx/choice.h>
+#include <wx/dir.h>
+#include <wx/dirdlg.h>
+#include <wx/filename.h>
+#include <wx/intl.h>
+#include <wx/log.h>
+#include <wx/sizer.h>
+#include <wx/textctrl.h>
+#include <wx/valgen.h>
+
+#include "CodeConversions.h"
+#include "EffectOutputTracks.h"
+#include "LoadEffects.h"
+#include "OpenVINOPluginPrefs.h"
+#include "Project.h"
+#include "ShuttleGui.h"
+#include "LabelTrack.h"
+#include "WaveTrack.h"
+#include "effects/EffectEditor.h"
+
+#include <openvino/openvino.hpp>
+#include "openvino/genai/speech_generation/text2speech_pipeline.hpp"
+
+const ComponentInterfaceSymbol EffectOVTextToSpeechGenAI::Symbol
+{ XO("OpenVINO Text-to-Speech") };
+
+namespace { BuiltinEffectsModule::Registration<EffectOVTextToSpeechGenAI> reg; }
+
+namespace {
+wxString FindSpeakerEmbeddingPath(const wxString& modelPath)
+{
+   const wxString voicesPath = wxFileName(modelPath, wxT("voices")).GetFullPath();
+   if (!wxDirExists(voicesPath)) {
+      throw std::runtime_error("The selected model folder does not contain a 'voices' directory.");
+   }
+
+   const wxString preferredVoice = wxFileName(voicesPath, wxT("af_heart.bin")).GetFullPath();
+   if (wxFileExists(preferredVoice)) {
+      return preferredVoice;
+   }
+
+   wxDir voicesDir(voicesPath);
+   wxString fileName;
+   if (!voicesDir.GetFirst(&fileName, wxT("*.bin"), wxDIR_FILES)) {
+      throw std::runtime_error("No speaker embedding .bin files were found in the model 'voices' directory.");
+   }
+
+   return wxFileName(voicesPath, fileName).GetFullPath();
+}
+
+size_t ShapeElementCount(const ov::Shape& shape)
+{
+   return std::accumulate(shape.begin(), shape.end(), static_cast<size_t>(1), std::multiplies<size_t>());
+}
+
+ov::Tensor LoadSpeakerEmbeddingTensor(const wxString& speakerEmbeddingPath, const ov::Shape& expectedShape)
+{
+   const size_t expectedElements = ShapeElementCount(expectedShape);
+   const size_t expectedBytes = expectedElements * sizeof(float);
+
+   std::ifstream input(audacity::ToUTF8(speakerEmbeddingPath), std::ios::binary);
+   if (!input) {
+      throw std::runtime_error("Failed to open speaker embedding file: " + audacity::ToUTF8(speakerEmbeddingPath));
+   }
+
+   ov::Tensor speakerEmbedding(ov::element::f32, expectedShape);
+   input.read(reinterpret_cast<char*>(speakerEmbedding.data<float>()), static_cast<std::streamsize>(expectedBytes));
+   if (!input || static_cast<size_t>(input.gcount()) != expectedBytes) {
+      throw std::runtime_error("Speaker embedding file size does not match the expected model embedding shape.");
+   }
+
+   return speakerEmbedding;
+}
+} // namespace
+
+BEGIN_EVENT_TABLE(EffectOVTextToSpeechGenAI, wxEvtHandler)
+   EVT_BUTTON(ID_Type_BrowseModelPath, EffectOVTextToSpeechGenAI::OnBrowseModelPath)
+END_EVENT_TABLE()
+
+EffectOVTextToSpeechGenAI::EffectOVTextToSpeechGenAI()
+{
+   ov::Core core;
+   auto devices = core.get_available_devices();
+
+   for (const auto& d : devices) {
+      if (d.find("GNA") != std::string::npos) {
+         continue;
+      }
+      mSupportedDevices.push_back(d);
+   }
+
+   for (const auto& d : mSupportedDevices) {
+      mGuiDeviceSelections.push_back({ TranslatableString{ wxString(d), {} } });
+   }
+
+   mSupportedTextSources = { "Manual text", "Selected label track" };
+   for (const auto& source : mSupportedTextSources) {
+      mGuiTextSourceSelections.push_back({ TranslatableString{ wxString(source), {} } });
+   }
+}
+
+EffectOVTextToSpeechGenAI::~EffectOVTextToSpeechGenAI() = default;
+
+ComponentInterfaceSymbol EffectOVTextToSpeechGenAI::GetSymbol() const
+{
+   return Symbol;
+}
+
+TranslatableString EffectOVTextToSpeechGenAI::GetDescription() const
+{
+   return XO("Generates speech from text using OpenVINO GenAI speech generation models");
+}
+
+VendorSymbol EffectOVTextToSpeechGenAI::GetVendor() const
+{
+   return XO("OpenVINO AI");
+}
+
+unsigned EffectOVTextToSpeechGenAI::GetAudioInCount() const
+{
+   return 0;
+}
+
+unsigned EffectOVTextToSpeechGenAI::GetAudioOutCount() const
+{
+   return 1;
+}
+
+EffectType EffectOVTextToSpeechGenAI::GetType() const
+{
+   return EffectTypeGenerate;
+}
+
+bool EffectOVTextToSpeechGenAI::IsInteractive() const
+{
+   return true;
+}
+
+std::vector<EffectOVTextToSpeechGenAI::LabelTextBlock> EffectOVTextToSpeechGenAI::ResolveSelectedLabelTrackBlocks() const
+{
+   constexpr double contiguousToleranceSeconds = 1e-6;
+   const bool hasTimeSelection = mT1 > mT0;
+
+   std::vector<LabelTextBlock> labels;
+
+   for (const auto labelTrack : mTracks->Selected<LabelTrack>()) {
+      for (const auto& label : labelTrack->GetLabels()) {
+         if (label.title.empty()) {
+            continue;
+         }
+
+         const double labelStart = label.selectedRegion.t0();
+         const double labelEnd = label.selectedRegion.t1();
+
+         bool includeLabel = true;
+         if (hasTimeSelection) {
+            includeLabel = labelEnd >= mT0 && labelStart <= mT1;
+         }
+
+         if (!includeLabel) {
+            continue;
+         }
+
+         labels.push_back({ labelStart, labelEnd, audacity::ToUTF8(label.title) });
+      }
+   }
+
+   std::sort(labels.begin(), labels.end(),
+      [](const LabelTextBlock& lhs, const LabelTextBlock& rhs) {
+         if (lhs.startTime != rhs.startTime) {
+            return lhs.startTime < rhs.startTime;
+         }
+         return lhs.endTime < rhs.endTime;
+      });
+
+   std::vector<LabelTextBlock> mergedBlocks;
+   for (const auto& label : labels) {
+      if (mergedBlocks.empty()) {
+         mergedBlocks.push_back(label);
+         continue;
+      }
+
+      auto& previous = mergedBlocks.back();
+      const bool isContiguous = std::abs(previous.endTime - label.startTime) <= contiguousToleranceSeconds;
+      if (!isContiguous) {
+         mergedBlocks.push_back(label);
+         continue;
+      }
+
+      previous.endTime = std::max(previous.endTime, label.endTime);
+      previous.text += label.text;
+   }
+
+   return mergedBlocks;
+}
+
+std::string EffectOVTextToSpeechGenAI::ResolvePromptText() const
+{
+   return mInputText;
+}
+
+bool EffectOVTextToSpeechGenAI::ApplyGeneratedBlocksToSelectedTracks(
+   const std::vector<GeneratedSpeechBlock>& generatedBlocks)
+{
+   if (generatedBlocks.empty()) {
+      return false;
+   }
+
+   EffectOutputTracks outputs { *mTracks, GetType(), { { mT0, mT1 } }, true };
+
+   bool appliedToAnyTrack = false;
+
+   for (auto pOutWaveTrack : outputs.Get().Selected<WaveTrack>()) {
+      double latestPlacedEnd = std::numeric_limits<double>::lowest();
+
+      for (const auto& block : generatedBlocks) {
+         if (block.speech.empty() || block.sampleRate == 0) {
+            continue;
+         }
+
+         double placementStart = block.preferredStartTime;
+         if (placementStart < latestPlacedEnd) {
+            placementStart = latestPlacedEnd;
+         }
+
+         auto generatedClip = pOutWaveTrack->EmptyCopy();
+         generatedClip->SetRate(block.sampleRate);
+         generatedClip->Append(
+            0,
+            reinterpret_cast<constSamplePtr>(block.speech.data()),
+            floatSample,
+            block.speech.size(),
+            1,
+            widestSampleFormat);
+         generatedClip->Flush();
+
+         constexpr auto preserve = true;
+         constexpr auto merge = true;
+         pOutWaveTrack->ClearAndPaste(
+            placementStart,
+            placementStart,
+            *generatedClip,
+            preserve,
+            merge,
+            nullptr);
+
+         const double blockDuration = static_cast<double>(block.speech.size()) / static_cast<double>(block.sampleRate);
+         latestPlacedEnd = placementStart + blockDuration;
+         appliedToAnyTrack = true;
+      }
+   }
+
+   if (appliedToAnyTrack) {
+      outputs.Commit();
+   }
+
+   return appliedToAnyTrack;
+}
+
+wxString EffectOVTextToSpeechGenAI::ResolveModelPath() const
+{
+   if (!mModelPath.empty()) {
+      return mModelPath;
+   }
+
+   const wxString openvinoModelsPath = OpenVINOPluginSettings::GetOrCreateModelDir(true);
+   const wxString speechGenerationDir = wxFileName(openvinoModelsPath, wxT("speech_generation")).GetFullPath();
+
+   if (!wxDirExists(speechGenerationDir)) {
+      return {};
+   }
+
+   wxDir speechDir(speechGenerationDir);
+
+   wxString subDirName;
+   bool hasDir = speechDir.GetFirst(&subDirName, wxEmptyString, wxDIR_DIRS);
+   while (hasDir) {
+      const wxString candidate = wxFileName(speechGenerationDir, subDirName).GetFullPath();
+      if (wxDirExists(wxFileName(candidate, wxT("voices")).GetFullPath())) {
+         return candidate;
+      }
+      hasDir = speechDir.GetNext(&subDirName);
+   }
+
+   return {};
+}
+
+bool EffectOVTextToSpeechGenAI::GenerateSpeech(const std::string& textToSpeak)
+{
+   if (mDeviceSelectionChoice < 0 || mDeviceSelectionChoice >= static_cast<int>(mSupportedDevices.size())) {
+      throw std::runtime_error("Invalid OpenVINO device selection.");
+   }
+
+   const wxString resolvedModelPath = ResolveModelPath();
+   if (resolvedModelPath.empty()) {
+      throw std::runtime_error(
+         "No text-to-speech model folder is configured. Set Model Folder to an exported OpenVINO GenAI speech model.");
+   }
+
+   const wxString speakerEmbeddingPath = FindSpeakerEmbeddingPath(resolvedModelPath);
+
+   const std::string deviceName = mSupportedDevices[mDeviceSelectionChoice];
+
+   ov::AnyMap properties;
+   properties["language"] = std::string("en-us");
+
+   if (OpenVINOPluginSettings::ReadEnableCache() && deviceName != "CPU") {
+      const auto cacheFolder = FileNames::MkDir(wxFileName(OpenVINOPluginSettings::GetOrCreateCompiledModelCacheDir()).GetFullPath());
+      properties[ov::cache_dir.name()] = audacity::ToUTF8(wxFileName(cacheFolder).GetFullPath());
+   }
+
+   ov::genai::Text2SpeechPipeline pipe(audacity::ToUTF8(resolvedModelPath), deviceName);
+   ov::Tensor speakerEmbedding = LoadSpeakerEmbeddingTensor(speakerEmbeddingPath, pipe.get_speaker_embedding_shape());
+
+   std::cout << "Generating speech for text: " << textToSpeak << std::endl;
+   auto result = pipe.generate(textToSpeak, speakerEmbedding, properties);
+   if (result.speeches.empty()) {
+      throw std::runtime_error("Text-to-speech generation returned no audio.");
+   }
+
+   const auto& waveform = result.speeches[0];
+   if (waveform.get_element_type() != ov::element::f32) {
+      throw std::runtime_error("Unexpected waveform type from text-to-speech model. Expected float32 output.");
+   }
+
+   mGeneratedSpeech.assign(waveform.data<const float>(), waveform.data<const float>() + waveform.get_size());
+   mGeneratedSampleRate = result.output_sample_rate;
+   return !mGeneratedSpeech.empty() && mGeneratedSampleRate > 0;
+}
+
+bool EffectOVTextToSpeechGenAI::Process(EffectInstance& instance, EffectSettings& settings)
+{
+   try {
+      mGeneratedSpeech.clear();
+      mGeneratedSampleRate = 0;
+
+      const auto source = static_cast<TextSource>(mTextSourceSelectionChoice);
+      if (source == TextSource::SelectedLabelTrack) {
+         const auto labelBlocks = ResolveSelectedLabelTrackBlocks();
+         if (labelBlocks.empty()) {
+            EffectUIServices::DoMessageBox(
+               *this,
+               XO("No labels with text were found in the selected label track(s) for the current selection."),
+               wxICON_STOP,
+               XO("Error"));
+            return false;
+         }
+
+         std::vector<GeneratedSpeechBlock> generatedBlocks;
+         generatedBlocks.reserve(labelBlocks.size());
+
+         for (const auto& block : labelBlocks) {
+            if (!GenerateSpeech(block.text)) {
+               EffectUIServices::DoMessageBox(
+                  *this,
+                  XO("Text-to-Speech generation produced no audio."),
+                  wxICON_STOP,
+                  XO("Error"));
+               return false;
+            }
+
+            generatedBlocks.push_back({
+               block.startTime,
+               mGeneratedSpeech,
+               mGeneratedSampleRate
+               });
+         }
+
+         if (!ApplyGeneratedBlocksToSelectedTracks(generatedBlocks)) {
+            EffectUIServices::DoMessageBox(
+               *this,
+               XO("Text-to-Speech needs at least one selected audio track to place generated snippets."),
+               wxICON_STOP,
+               XO("Error"));
+            return false;
+         }
+
+         return true;
+      }
+
+      const std::string textToSpeak = ResolvePromptText();
+      if (textToSpeak.empty()) {
+         EffectUIServices::DoMessageBox(
+            *this,
+            XO("Text-to-Speech needs input text. Enter text manually or select a label track with labels in the current selection."),
+            wxICON_STOP,
+            XO("Error"));
+         return false;
+      }
+
+      if (!GenerateSpeech(textToSpeak)) {
+         EffectUIServices::DoMessageBox(
+            *this,
+            XO("Text-to-Speech generation produced no audio."),
+            wxICON_STOP,
+            XO("Error"));
+         return false;
+      }
+
+      const double durationSeconds = static_cast<double>(mGeneratedSpeech.size()) / static_cast<double>(mGeneratedSampleRate);
+      settings.extra.SetDuration(durationSeconds);
+
+      return Generator::Process(instance, settings);
+   }
+   catch (const std::exception& error) {
+      wxLogError("In Text-to-Speech effect, exception: %s", error.what());
+      EffectUIServices::DoMessageBox(*this,
+         XO("Text-to-Speech failed. See details in Help->Diagnostics->Show Log..."),
+         wxICON_STOP,
+         XO("Error"));
+      return false;
+   }
+}
+
+bool EffectOVTextToSpeechGenAI::GenerateTrack(const EffectSettings&, WaveTrack& tmp)
+{
+   if (mGeneratedSpeech.empty()) {
+      return false;
+   }
+
+   // Set the track to the native sample rate of the generated audio
+   tmp.SetRate(mGeneratedSampleRate);
+
+   tmp.Append(0,
+      reinterpret_cast<constSamplePtr>(mGeneratedSpeech.data()),
+      floatSample,
+      mGeneratedSpeech.size(),
+      1,
+      widestSampleFormat);
+
+   return true;
+}
+
+std::unique_ptr<EffectEditor> EffectOVTextToSpeechGenAI::PopulateOrExchange(
+   ShuttleGui& S, EffectInstance&, EffectSettingsAccess&, const EffectOutputs*)
+{
+   mUIParent = S.GetParent();
+
+   if (mModelPath.empty()) {
+      mModelPath = ResolveModelPath();
+   }
+
+   S.AddSpace(0, 5);
+   S.StartVerticalLay();
+   {
+      S.StartMultiColumn(2, wxEXPAND);
+      {
+         mTypeChoiceDeviceCtrl = S.Id(ID_Type_Device)
+            .MinSize({ -1, -1 })
+            .Validator<wxGenericValidator>(&mDeviceSelectionChoice)
+            .AddChoice(XXO("OpenVINO Inference Device:"),
+               Msgids(mGuiDeviceSelections.data(), mGuiDeviceSelections.size()));
+
+         mTypeChoiceTextSourceCtrl = S.Id(ID_Type_TextSource)
+            .MinSize({ -1, -1 })
+            .Validator<wxGenericValidator>(&mTextSourceSelectionChoice)
+            .AddChoice(XXO("Text Source:"),
+               Msgids(mGuiTextSourceSelections.data(), mGuiTextSourceSelections.size()));
+      }
+      S.EndMultiColumn();
+
+      S.StartMultiColumn(1, wxEXPAND);
+      {
+         mInputTextCtrl = S.Style(wxTE_LEFT | wxTE_MULTILINE)
+            .AddTextBox(XXO("Text:"), wxString::FromUTF8(mInputText), 50);
+      }
+      S.EndMultiColumn();
+
+      S.StartMultiColumn(3, wxEXPAND);
+      {
+         mModelPathCtrl = S.Id(ID_Type_ModelPath)
+            .Style(wxTE_LEFT)
+            .AddTextBox(XXO("Model Folder:"), mModelPath, 40);
+
+         S.Id(ID_Type_BrowseModelPath).AddButton(XO("Browse..."));
+      }
+      S.EndMultiColumn();
+   }
+   S.EndVerticalLay();
+
+   return nullptr;
+}
+
+bool EffectOVTextToSpeechGenAI::TransferDataToWindow(const EffectSettings&)
+{
+   if (!mUIParent || !mUIParent->TransferDataToWindow()) {
+      return false;
+   }
+
+   if (mSupportedDevices.empty()) {
+      wxLogInfo("OpenVINO Text-to-Speech has no supported inference devices.");
+      EffectEditor::EnableApply(mUIParent, false);
+   }
+
+   return true;
+}
+
+bool EffectOVTextToSpeechGenAI::TransferDataFromWindow(EffectSettings&)
+{
+   if (!mUIParent || !mUIParent->Validate() || !mUIParent->TransferDataFromWindow()) {
+      return false;
+   }
+
+   mInputText = audacity::ToUTF8(mInputTextCtrl->GetValue());
+   mModelPath = mModelPathCtrl->GetValue();
+   return true;
+}
+
+void EffectOVTextToSpeechGenAI::OnBrowseModelPath(wxCommandEvent&)
+{
+   wxDirDialog dialog(
+      mUIParent.get(),
+      XO("Choose an OpenVINO GenAI text-to-speech model directory").Translation(),
+      mModelPath.empty() ? OpenVINOPluginSettings::GetOrCreateModelDir(true) : mModelPath,
+      wxDD_DEFAULT_STYLE | wxDD_DIR_MUST_EXIST);
+
+   if (dialog.ShowModal() == wxID_OK && mModelPathCtrl) {
+      mModelPathCtrl->SetValue(dialog.GetPath());
+   }
+}

--- a/mod-openvino/OVTextToSpeechGenAI.cpp
+++ b/mod-openvino/OVTextToSpeechGenAI.cpp
@@ -318,7 +318,10 @@ std::vector<EffectOVTextToSpeechGenAI::LabelTextBlock> EffectOVTextToSpeechGenAI
 
          bool includeLabel = true;
          if (hasTimeSelection) {
-            includeLabel = labelEnd >= mT0 && labelStart <= mT1;
+            // Only include labels with non-zero overlap; labels that only
+            // touch selection boundaries should be excluded.
+            includeLabel = (labelEnd - mT0) > contiguousToleranceSeconds
+               && (mT1 - labelStart) > contiguousToleranceSeconds;
          }
 
          if (!includeLabel) {

--- a/mod-openvino/OVTextToSpeechGenAI.cpp
+++ b/mod-openvino/OVTextToSpeechGenAI.cpp
@@ -772,12 +772,11 @@ std::unique_ptr<EffectEditor> EffectOVTextToSpeechGenAI::PopulateOrExchange(
       }
       S.EndMultiColumn();
 
-      S.StartMultiColumn(1, wxEXPAND);
-      {
-         mInputTextCtrl = S.Style(wxTE_LEFT | wxTE_MULTILINE)
-            .AddTextBox(XXO("Text:"), wxString::FromUTF8(mInputText), 50);
-      }
-      S.EndMultiColumn();
+      S.AddVariableText(XO("Text:"));
+      mInputTextCtrl = S.Name(XO("Text"))
+         .Style(wxTE_MULTILINE)
+         .MinSize(wxSize(500, 120))
+         .AddTextWindow(wxString::FromUTF8(mInputText));
    }
    S.EndVerticalLay();
 

--- a/mod-openvino/OVTextToSpeechGenAI.cpp
+++ b/mod-openvino/OVTextToSpeechGenAI.cpp
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <cmath>
 #include <fstream>
+#include <future>
 #include <limits>
 #include <numeric>
 #include <stdexcept>
@@ -649,6 +650,32 @@ bool EffectOVTextToSpeechGenAI::GenerateSpeech(const std::string& textToSpeak)
 bool EffectOVTextToSpeechGenAI::Process(EffectInstance& instance, EffectSettings& settings)
 {
    try {
+      if (TotalProgress(0.0, XO("Preparing Text-to-Speech generation..."))) {
+         return false;
+      }
+
+      auto generateSpeechWithUiPump =
+         [this](const std::string& text, double progress, const TranslatableString& message) {
+            auto generationFuture = std::async(std::launch::async, [this, text]() {
+               return GenerateSpeech(text);
+            });
+
+            bool cancelRequested = false;
+            std::future_status status;
+            do {
+               using namespace std::chrono_literals;
+               status = generationFuture.wait_for(200ms);
+               if (status != std::future_status::ready) {
+                  if (TotalProgress(progress, message)) {
+                     cancelRequested = true;
+                  }
+               }
+            } while (status != std::future_status::ready);
+
+            const bool generated = generationFuture.get();
+            return generated && !cancelRequested;
+         };
+
       mGeneratedSpeech.clear();
       mGeneratedSampleRate = 0;
 
@@ -667,8 +694,18 @@ bool EffectOVTextToSpeechGenAI::Process(EffectInstance& instance, EffectSettings
          std::vector<GeneratedSpeechBlock> generatedBlocks;
          generatedBlocks.reserve(labelBlocks.size());
 
-         for (const auto& block : labelBlocks) {
-            if (!GenerateSpeech(block.text)) {
+         const double generationStartProgress = 0.05;
+         const double generationEndProgress = 0.90;
+         for (size_t blockIndex = 0; blockIndex < labelBlocks.size(); ++blockIndex) {
+            const auto& block = labelBlocks[blockIndex];
+            const double blockProgress = generationStartProgress
+               + (generationEndProgress - generationStartProgress)
+               * (static_cast<double>(blockIndex) / static_cast<double>(labelBlocks.size()));
+            if (TotalProgress(blockProgress, XO("Generating speech from selected label track..."))) {
+               return false;
+            }
+
+            if (!generateSpeechWithUiPump(block.text, blockProgress, XO("Generating speech from selected label track..."))) {
                EffectUIServices::DoMessageBox(
                   *this,
                   XO("Text-to-Speech generation produced no audio."),
@@ -684,6 +721,10 @@ bool EffectOVTextToSpeechGenAI::Process(EffectInstance& instance, EffectSettings
                });
          }
 
+         if (TotalProgress(0.93, XO("Placing generated speech..."))) {
+            return false;
+         }
+
          const bool applied = mGenerateIntoNewTrack
             ? ApplyGeneratedBlocksToNewTrack(generatedBlocks)
             : ApplyGeneratedBlocksToSelectedTracks(generatedBlocks);
@@ -696,6 +737,8 @@ bool EffectOVTextToSpeechGenAI::Process(EffectInstance& instance, EffectSettings
                XO("Error"));
             return false;
          }
+
+         (void)TotalProgress(1.0, XO("Text-to-Speech generation complete."));
 
          return true;
       }
@@ -710,7 +753,11 @@ bool EffectOVTextToSpeechGenAI::Process(EffectInstance& instance, EffectSettings
          return false;
       }
 
-      if (!GenerateSpeech(textToSpeak)) {
+      if (TotalProgress(0.10, XO("Generating speech..."))) {
+         return false;
+      }
+
+      if (!generateSpeechWithUiPump(textToSpeak, 0.10, XO("Generating speech..."))) {
          EffectUIServices::DoMessageBox(
             *this,
             XO("Text-to-Speech generation produced no audio."),
@@ -719,8 +766,14 @@ bool EffectOVTextToSpeechGenAI::Process(EffectInstance& instance, EffectSettings
          return false;
       }
 
+      if (TotalProgress(0.95, XO("Finalizing generated audio..."))) {
+         return false;
+      }
+
       const double durationSeconds = static_cast<double>(mGeneratedSpeech.size()) / static_cast<double>(mGeneratedSampleRate);
       settings.extra.SetDuration(durationSeconds);
+
+      (void)TotalProgress(1.0, XO("Text-to-Speech generation complete."));
 
       return Generator::Process(instance, settings);
    }

--- a/mod-openvino/OVTextToSpeechGenAI.h
+++ b/mod-openvino/OVTextToSpeechGenAI.h
@@ -77,14 +77,17 @@ private:
 
    bool GenerateTrack(const EffectSettings& settings, WaveTrack& tmp) override;
 
+   bool HasSelectedLabelTracks() const;
    std::string ResolvePromptText() const;
    std::vector<LabelTextBlock> ResolveSelectedLabelTrackBlocks() const;
    bool GenerateSpeech(const std::string& textToSpeak);
    bool ApplyGeneratedBlocksToSelectedTracks(const std::vector<GeneratedSpeechBlock>& generatedBlocks);
    std::string ResolveModelPath() const;
    void RefreshVoicesForCurrentModel();
+   void UpdateInputTextEnabledState();
 
    void OnModelManagerButtonClicked(wxCommandEvent& evt);
+   void OnTextSourceChanged(wxCommandEvent& evt);
    void OnTtsModelChanged(wxCommandEvent& evt);
    void OnLanguageChanged(wxCommandEvent& evt);
    void OnFilterVoicesByLanguageChanged(wxCommandEvent& evt);

--- a/mod-openvino/OVTextToSpeechGenAI.h
+++ b/mod-openvino/OVTextToSpeechGenAI.h
@@ -62,8 +62,8 @@ private:
    {
       ID_Type_Device = 14000,
       ID_Type_TextSource,
-      ID_Type_ModelPath,
-      ID_Type_BrowseModelPath
+      ID_Type_TtsModel,
+      ID_Type_ModelManager
    };
 
    enum class TextSource
@@ -78,9 +78,9 @@ private:
    std::vector<LabelTextBlock> ResolveSelectedLabelTrackBlocks() const;
    bool GenerateSpeech(const std::string& textToSpeak);
    bool ApplyGeneratedBlocksToSelectedTracks(const std::vector<GeneratedSpeechBlock>& generatedBlocks);
-   wxString ResolveModelPath() const;
+   std::string ResolveModelPath() const;
 
-   void OnBrowseModelPath(wxCommandEvent& evt);
+   void OnModelManagerButtonClicked(wxCommandEvent& evt);
 
    wxWeakRef<wxWindow> mUIParent{};
 
@@ -94,11 +94,14 @@ private:
    std::vector<std::string> mSupportedTextSources;
    std::vector<EnumValueSymbol> mGuiTextSourceSelections;
 
+   wxChoice* mTypeChoiceTtsModelCtrl{};
+   int mTtsModelSelectionChoice = 0;
+   std::vector<std::string> mSupportedTtsModels;
+   std::vector<EnumValueSymbol> mGuiTtsModelSelections;
+
    wxTextCtrl* mInputTextCtrl{};
-   wxTextCtrl* mModelPathCtrl{};
 
    std::string mInputText;
-   wxString mModelPath;
 
    std::vector<float> mGeneratedSpeech;
    uint32_t mGeneratedSampleRate = 0;

--- a/mod-openvino/OVTextToSpeechGenAI.h
+++ b/mod-openvino/OVTextToSpeechGenAI.h
@@ -63,7 +63,9 @@ private:
       ID_Type_Device = 14000,
       ID_Type_TextSource,
       ID_Type_TtsModel,
-      ID_Type_ModelManager
+      ID_Type_ModelManager,
+      ID_Type_Voice,
+      ID_Type_Language
    };
 
    enum class TextSource
@@ -79,8 +81,10 @@ private:
    bool GenerateSpeech(const std::string& textToSpeak);
    bool ApplyGeneratedBlocksToSelectedTracks(const std::vector<GeneratedSpeechBlock>& generatedBlocks);
    std::string ResolveModelPath() const;
+   void RefreshVoicesForCurrentModel();
 
    void OnModelManagerButtonClicked(wxCommandEvent& evt);
+   void OnTtsModelChanged(wxCommandEvent& evt);
 
    wxWeakRef<wxWindow> mUIParent{};
 
@@ -98,6 +102,16 @@ private:
    int mTtsModelSelectionChoice = 0;
    std::vector<std::string> mSupportedTtsModels;
    std::vector<EnumValueSymbol> mGuiTtsModelSelections;
+
+   wxChoice* mTypeChoiceVoiceCtrl{};
+   int mVoiceSelectionChoice = 0;
+   std::vector<std::string> mSupportedVoices;
+   std::vector<EnumValueSymbol> mGuiVoiceSelections;
+
+   wxChoice* mTypeChoiceLanguageCtrl{};
+   int mLanguageSelectionChoice = 0;
+   std::vector<std::string> mSupportedLanguages;
+   std::vector<EnumValueSymbol> mGuiLanguageSelections;
 
    wxTextCtrl* mInputTextCtrl{};
 

--- a/mod-openvino/OVTextToSpeechGenAI.h
+++ b/mod-openvino/OVTextToSpeechGenAI.h
@@ -125,7 +125,7 @@ private:
    std::vector<std::string> mSupportedLanguages;
    std::vector<std::string> mSupportedLanguageCodes;
    std::vector<EnumValueSymbol> mGuiLanguageSelections;
-   bool mFilterVoicesByLanguage = false;
+   bool mFilterVoicesByLanguage = true;
    wxCheckBox* mGenerateIntoNewTrackCtrl{};
    bool mGenerateIntoNewTrack = true;
 

--- a/mod-openvino/OVTextToSpeechGenAI.h
+++ b/mod-openvino/OVTextToSpeechGenAI.h
@@ -111,6 +111,7 @@ private:
    wxChoice* mTypeChoiceLanguageCtrl{};
    int mLanguageSelectionChoice = 0;
    std::vector<std::string> mSupportedLanguages;
+   std::vector<std::string> mSupportedLanguageCodes;
    std::vector<EnumValueSymbol> mGuiLanguageSelections;
 
    wxTextCtrl* mInputTextCtrl{};

--- a/mod-openvino/OVTextToSpeechGenAI.h
+++ b/mod-openvino/OVTextToSpeechGenAI.h
@@ -1,0 +1,107 @@
+// Copyright (C) 2026 Intel Corporation
+// SPDX-License-Identifier: GPL-3.0-only
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "Generator.h"
+#include "effects/StatefulEffectUIServices.h"
+
+#include <wx/weakref.h>
+
+class LabelTrack;
+class wxChoice;
+class wxTextCtrl;
+
+class EffectOVTextToSpeechGenAI final : public Generator, public StatefulEffectUIServices
+{
+public:
+   static const ComponentInterfaceSymbol Symbol;
+
+   EffectOVTextToSpeechGenAI();
+   ~EffectOVTextToSpeechGenAI() override;
+
+   ComponentInterfaceSymbol GetSymbol() const override;
+   TranslatableString GetDescription() const override;
+   VendorSymbol GetVendor() const override;
+
+   unsigned GetAudioInCount() const override;
+   unsigned GetAudioOutCount() const override;
+
+   EffectType GetType() const override;
+   bool IsInteractive() const override;
+
+   bool Process(EffectInstance& instance, EffectSettings& settings) override;
+
+   std::unique_ptr<EffectEditor> PopulateOrExchange(
+      ShuttleGui& S, EffectInstance& instance,
+      EffectSettingsAccess& access, const EffectOutputs* pOutputs) override;
+
+protected:
+   bool TransferDataToWindow(const EffectSettings& settings) override;
+   bool TransferDataFromWindow(EffectSettings& settings) override;
+
+private:
+   struct LabelTextBlock
+   {
+      double startTime = 0.0;
+      double endTime = 0.0;
+      std::string text;
+   };
+
+   struct GeneratedSpeechBlock
+   {
+      double preferredStartTime = 0.0;
+      std::vector<float> speech;
+      uint32_t sampleRate = 0;
+   };
+
+   enum control
+   {
+      ID_Type_Device = 14000,
+      ID_Type_TextSource,
+      ID_Type_ModelPath,
+      ID_Type_BrowseModelPath
+   };
+
+   enum class TextSource
+   {
+      ManualText = 0,
+      SelectedLabelTrack = 1
+   };
+
+   bool GenerateTrack(const EffectSettings& settings, WaveTrack& tmp) override;
+
+   std::string ResolvePromptText() const;
+   std::vector<LabelTextBlock> ResolveSelectedLabelTrackBlocks() const;
+   bool GenerateSpeech(const std::string& textToSpeak);
+   bool ApplyGeneratedBlocksToSelectedTracks(const std::vector<GeneratedSpeechBlock>& generatedBlocks);
+   wxString ResolveModelPath() const;
+
+   void OnBrowseModelPath(wxCommandEvent& evt);
+
+   wxWeakRef<wxWindow> mUIParent{};
+
+   wxChoice* mTypeChoiceDeviceCtrl{};
+   int mDeviceSelectionChoice = 0;
+   std::vector<std::string> mSupportedDevices;
+   std::vector<EnumValueSymbol> mGuiDeviceSelections;
+
+   wxChoice* mTypeChoiceTextSourceCtrl{};
+   int mTextSourceSelectionChoice = 0;
+   std::vector<std::string> mSupportedTextSources;
+   std::vector<EnumValueSymbol> mGuiTextSourceSelections;
+
+   wxTextCtrl* mInputTextCtrl{};
+   wxTextCtrl* mModelPathCtrl{};
+
+   std::string mInputText;
+   wxString mModelPath;
+
+   std::vector<float> mGeneratedSpeech;
+   uint32_t mGeneratedSampleRate = 0;
+
+   DECLARE_EVENT_TABLE()
+};

--- a/mod-openvino/OVTextToSpeechGenAI.h
+++ b/mod-openvino/OVTextToSpeechGenAI.h
@@ -12,6 +12,7 @@
 #include <wx/weakref.h>
 
 class LabelTrack;
+class wxCheckBox;
 class wxChoice;
 class wxTextCtrl;
 
@@ -66,7 +67,8 @@ private:
       ID_Type_ModelManager,
       ID_Type_Voice,
       ID_Type_Language,
-      ID_Type_FilterVoicesByLanguage
+      ID_Type_FilterVoicesByLanguage,
+      ID_Type_GenerateIntoNewTrack
    };
 
    enum class TextSource
@@ -81,10 +83,13 @@ private:
    std::string ResolvePromptText() const;
    std::vector<LabelTextBlock> ResolveSelectedLabelTrackBlocks() const;
    bool GenerateSpeech(const std::string& textToSpeak);
+   bool ApplyGeneratedBlocksToTrack(WaveTrack& destinationTrack, const std::vector<GeneratedSpeechBlock>& generatedBlocks);
+   bool ApplyGeneratedBlocksToNewTrack(const std::vector<GeneratedSpeechBlock>& generatedBlocks);
    bool ApplyGeneratedBlocksToSelectedTracks(const std::vector<GeneratedSpeechBlock>& generatedBlocks);
    std::string ResolveModelPath() const;
    void RefreshVoicesForCurrentModel();
    void UpdateInputTextEnabledState();
+   void UpdateTextSourceDependentControlStates();
 
    void OnModelManagerButtonClicked(wxCommandEvent& evt);
    void OnTextSourceChanged(wxCommandEvent& evt);
@@ -121,6 +126,8 @@ private:
    std::vector<std::string> mSupportedLanguageCodes;
    std::vector<EnumValueSymbol> mGuiLanguageSelections;
    bool mFilterVoicesByLanguage = false;
+   wxCheckBox* mGenerateIntoNewTrackCtrl{};
+   bool mGenerateIntoNewTrack = true;
 
    wxTextCtrl* mInputTextCtrl{};
 

--- a/mod-openvino/OVTextToSpeechGenAI.h
+++ b/mod-openvino/OVTextToSpeechGenAI.h
@@ -65,7 +65,8 @@ private:
       ID_Type_TtsModel,
       ID_Type_ModelManager,
       ID_Type_Voice,
-      ID_Type_Language
+      ID_Type_Language,
+      ID_Type_FilterVoicesByLanguage
    };
 
    enum class TextSource
@@ -85,6 +86,8 @@ private:
 
    void OnModelManagerButtonClicked(wxCommandEvent& evt);
    void OnTtsModelChanged(wxCommandEvent& evt);
+   void OnLanguageChanged(wxCommandEvent& evt);
+   void OnFilterVoicesByLanguageChanged(wxCommandEvent& evt);
 
    wxWeakRef<wxWindow> mUIParent{};
 
@@ -106,6 +109,7 @@ private:
    wxChoice* mTypeChoiceVoiceCtrl{};
    int mVoiceSelectionChoice = 0;
    std::vector<std::string> mSupportedVoices;
+   std::vector<std::string> mVisibleVoices;
    std::vector<EnumValueSymbol> mGuiVoiceSelections;
 
    wxChoice* mTypeChoiceLanguageCtrl{};
@@ -113,6 +117,7 @@ private:
    std::vector<std::string> mSupportedLanguages;
    std::vector<std::string> mSupportedLanguageCodes;
    std::vector<EnumValueSymbol> mGuiLanguageSelections;
+   bool mFilterVoicesByLanguage = false;
 
    wxTextCtrl* mInputTextCtrl{};
 

--- a/mod-openvino/model_md_card_info.h
+++ b/mod-openvino/model_md_card_info.h
@@ -183,7 +183,7 @@ const char* text_to_speech_kokoro_82m = R"md(
 <p>Source model: <a href="https://huggingface.co/hexgrad/Kokoro-82M">https://huggingface.co/hexgrad/Kokoro-82M</a></p>
 <p>For use with <a href="https://github.com/intel/openvino-plugins-ai-audacity">OpenVINO AI Plugins for Audacity</a>, the model is converted to OpenVINO IR format.</p>
 <p>Since a public OpenVINO-converted download location is not yet available, this model cannot currently be downloaded via the Model Manager.</p>
-<p>To use it, place the converted model folder (containing <code>openvino_model.xml</code>, <code>openvino_model.bin</code>, <code>config.json</code>, and the <code>voices/</code> and <code>data/</code> subdirectories) into <code>openvino-models/speech_generation/kokoro-82m/</code>, and restart Audacity.</p>
+<p>To use it, place the converted model folder (containing <code>openvino_model.xml</code>, <code>openvino_model.bin</code>, <code>config.json</code>, and the <code>voices/</code> and <code>data/</code> subdirectories) into <code>openvino-models/text_to_speech/ov_Kokoro-82M/</code>, and restart Audacity.</p>
 <p>After restart, the model should appear as installed/selectable in the Text-to-Speech generator and in the Model Manager.</p>
 <h2>License</h2>
 <p><a href="https://choosealicense.com/licenses/apache-2.0/">Apache-2.0</a></p>

--- a/mod-openvino/model_md_card_info.h
+++ b/mod-openvino/model_md_card_info.h
@@ -176,6 +176,19 @@ const char* super_resolution_speech = R"md(
 <p>License: <a href="https://github.com/haoheliu/versatile_audio_super_resolution?tab=MIT-1-ov-file#readme">MIT</a></p>
 )md";
 
+const char* text_to_speech_kokoro_82m = R"md(
+<h1>Kokoro-82M</h1>
+<p>Kokoro is a lightweight, high-quality text-to-speech model with 82 million parameters. It supports multiple voices and languages.</p>
+<p>The model ships with a large set of speaker embedding voices across several languages, including US English, British English, French, Spanish, Japanese, Chinese, Hindi, Italian, Portuguese, and Vietnamese.</p>
+<p>Source model: <a href="https://huggingface.co/hexgrad/Kokoro-82M">https://huggingface.co/hexgrad/Kokoro-82M</a></p>
+<p>For use with <a href="https://github.com/intel/openvino-plugins-ai-audacity">OpenVINO AI Plugins for Audacity</a>, the model is converted to OpenVINO IR format.</p>
+<p>Since a public OpenVINO-converted download location is not yet available, this model cannot currently be downloaded via the Model Manager.</p>
+<p>To use it, place the converted model folder (containing <code>openvino_model.xml</code>, <code>openvino_model.bin</code>, <code>config.json</code>, and the <code>voices/</code> and <code>data/</code> subdirectories) into <code>openvino-models/speech_generation/kokoro-82m/</code>, and restart Audacity.</p>
+<p>After restart, the model should appear as installed/selectable in the Text-to-Speech generator and in the Model Manager.</p>
+<h2>License</h2>
+<p><a href="https://choosealicense.com/licenses/apache-2.0/">Apache-2.0</a></p>
+)md";
+
 const char* whisper_transcription_info = R"md(
 <h2>Quantization Guide</h2>
 <p>The Whisper models available to use with this project come in three <em>quantization</em> variants: <em>FP16</em>, <em>INT8</em>, &amp; <em>INT4</em>.</p>

--- a/model_cards/text_to_speech/kokoro_82m.md
+++ b/model_cards/text_to_speech/kokoro_82m.md
@@ -1,0 +1,19 @@
+# Kokoro-82M
+
+Kokoro is a lightweight, high-quality text-to-speech model with 82 million parameters. It supports multiple voices and languages.
+
+The model ships with a large set of speaker embedding voices across several languages, including US English, British English, French, Spanish, Japanese, Chinese, Hindi, Italian, Portuguese, and Vietnamese.
+
+Source model: [https://huggingface.co/hexgrad/Kokoro-82M](https://huggingface.co/hexgrad/Kokoro-82M)
+
+For use with [OpenVINO AI Plugins for Audacity](https://github.com/intel/openvino-plugins-ai-audacity), the model is converted to OpenVINO IR format.
+
+Since a public OpenVINO-converted download location is not yet available, this model cannot currently be downloaded via the Model Manager.
+
+To use it, place the converted model folder (containing `openvino_model.xml`, `openvino_model.bin`, `config.json`, and the `voices/` and `data/` subdirectories) into `openvino-models/speech_generation/kokoro-82m/`, and restart Audacity.
+
+After restart, the model should appear as installed/selectable in the Text-to-Speech generator and in the Model Manager.
+
+## License
+
+[Apache-2.0](https://choosealicense.com/licenses/apache-2.0/)

--- a/tools/windows/prereq.bat
+++ b/tools/windows/prereq.bat
@@ -9,8 +9,8 @@ set "bat_path=%~dp0"
 set LIBTORCH_PACKAGE_URL="https://download.pytorch.org/libtorch/cpu/libtorch-win-shared-with-deps-2.4.1%%%%2Bcpu.zip"
 set LIBTORCH_PACKAGE_256SUM=e7b8d0b3b958d2215f52ff5385335f93aa78e42005727e44f1043d94d5bfc5dd
 
-set OPENVINO_GENAI_PACKAGE_URL=https://storage.openvinotoolkit.org/repositories/openvino_genai/packages/2026.1.3.0/windows/openvino_genai_windows_2026.1.3.0_x86_64.zip
-set OPENVINO_GENAI_PACKAGE_256SUM=99051c06be97f8cf56d68b03cb3f9861efd9c4dc7a619599ed1a5d36e9d04780
+set OPENVINO_GENAI_PACKAGE_URL=https://storage.openvinotoolkit.org/repositories/openvino_genai/packages/nightly/2026.3.0.0.dev20260521/openvino_genai_windows_2026.3.0.0.dev20260521_x86_64.zip
+set OPENVINO_GENAI_PACKAGE_256SUM=f2a2c3f9904ab3146c5aca72f0c2b28b1037c6dc04b21cdd99ad59d0a25b7209
 
 :::::::::::::::::::::::::::::
 ::  GIT Repo Configuration ::
@@ -33,13 +33,17 @@ if not defined LIBTORCH_DIR (
     echo Not downloading Libtorch, as LIBTORCH_DIR is defined by environment. LIBTORCH_DIR=%LIBTORCH_DIR%
 )
 
-call :DownloadVerifyExtract %OPENVINO_GENAI_PACKAGE_URL% %OPENVINO_GENAI_PACKAGE_256SUM%
-IF "%EXTRACTED_PACKAGE_PATH%"=="" (
-echo Error in openvino genai download routine..
-exit /b
-)
+if not defined OPENVINO_GENAI_DIR (
+	call :DownloadVerifyExtract %OPENVINO_GENAI_PACKAGE_URL% %OPENVINO_GENAI_PACKAGE_256SUM%
+	IF "!EXTRACTED_PACKAGE_PATH!"=="" (
+	echo Error in openvino genai download routine..
+	exit /b
+	)
 
-set OPENVINO_GENAI_DIR=%EXTRACTED_PACKAGE_PATH%
+	set OPENVINO_GENAI_DIR=!EXTRACTED_PACKAGE_PATH!
+) else (
+    echo Not downloading OpenVINO GenAI, as OPENVINO_GENAI_DIR is defined by environment. OPENVINO_GENAI_DIR=%OPENVINO_GENAI_DIR%
+)
 
 
 :: Clone the required repo's and check out the desired tags


### PR DESCRIPTION
This PR introduces a new effect, Text-to-Speech -- which acts as a Generator.

The input text source can come from either:
1. A block of text pasted into the effect dialog box:
<img width="769" height="761" alt="image" src="https://github.com/user-attachments/assets/6738d9e4-57f6-4be2-9cfe-61240e5ec447" />

2. The text from a label track that may be selected. The effect will automatically detect if a label track has been selected. If so, it will default the input source selection to the label track:
<img width="1758" height="968" alt="image" src="https://github.com/user-attachments/assets/67d34ebb-985b-410c-b2f1-1b0589e7cbb4" />

Having the ability to select the input source as a label track allows the following workflow:
1. Transcribe some audio segment using whisper, producing a label track
2. Select the label track, and produce speech

Future PR's will enhance this feature. Currently, the model needs to be manually exported from optimum, as it hasn't (yet) been posted to OpenVINO's HuggingFace project. In other words, it doesn't yet support one-click install from the Model Manager GUI.